### PR TITLE
misc fixes and test enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Both players must have a funded Kaspa address to pay for transaction fees. The a
     ```bash
     ./target/release/ttt
     ```
-2.  The program will output a Kaspa address and a private key. Send some testnet Kaspa (TKAS) to the address. You can get testnet funds from the [Kaspa Faucet](https://www.google.com/search?q=https://faucet.kaspanet.io/).
+2.  The program will output a Kaspa address and a private key. Send some testnet Kaspa (TKAS) to the address. You can get testnet funds from the [Kaspa Faucet](https://faucet.kaspanet.io/).
 
 #### Step 3: Player 1 (Starts the Session)
 

--- a/kdapp/src/engine.rs
+++ b/kdapp/src/engine.rs
@@ -16,7 +16,7 @@ use std::marker::PhantomData;
 use std::sync::mpsc::Receiver;
 
 const EPISODE_LIFETIME: u64 = 2592000; // Three days
-const SAMPLE_REMOVAL_TIME: u64 = 432000; // Half a day
+const SAMPLE_REMOVAL_TIME: u64 = 432000; // Five days
 
 pub(crate) struct EpisodeWrapper<G: Episode> {
     pub episode: G,


### PR DESCRIPTION
## Summary
- link directly to Kaspa faucet in README
- bound `Sig` borsh deserialization to a length prefix
- correct sample removal time comment in engine
- assert engine rollback restores TicTacToe state

## Testing
- ⚠️ `cargo test --workspace` (not run: repository guidelines prohibit running cargo commands)


------
https://chatgpt.com/codex/tasks/task_e_68b5700d0bbc832bb01c58e887378b19