### PR TITLE
docs: clarify deterministic challenge generation

### DIFF
--- a/examples/comment-it/src/crypto/challenges.rs
+++ b/examples/comment-it/src/crypto/challenges.rs
@@ -26,7 +26,8 @@ impl ChallengeGenerator {
         (challenge, timestamp)
     }
 
-    /// Generate a challenge with a provided timestamp for expiry
+    /// Generate a challenge deterministically seeded by the provided timestamp.
+    /// The caller may use the embedded timestamp to enforce expiry if desired.
     pub fn generate_with_provided_timestamp(timestamp: u64) -> String {
         let mut rng = ChaCha8Rng::seed_from_u64(timestamp);
         format!("auth_{}_{}", timestamp, rng.gen::<u64>())


### PR DESCRIPTION
## Summary
- clarify comment for deterministic challenge generation without implying expiry

## Testing
- Not run

------
https://chatgpt.com/codex/tasks/task_e_68b5806b4f00832ba993b0c88a4cf651