### PR TITLE
feat(merchant): add proxy listener and routing ids

### DIFF
--- a/examples/kdapp-merchant/onlyKAS-merchant.md
+++ b/examples/kdapp-merchant/onlyKAS-merchant.md
@@ -15,16 +15,18 @@ Files
 - examples/kdapp-merchant/src/sim_router.rs: simple EpisodeMessage → Engine wiring
 - examples/kdapp-merchant/src/tlv.rs: TLV v1 helpers
 - examples/kdapp-merchant/src/program_id.rs: derive_program_label helper
-- examples/kdapp-merchant/src/main.rs: demo runner and wiring
+- examples/kdapp-merchant/src/main.rs: demo runner, proxy listener and wiring
 
 Quickstart
 - Build: `cargo build -p kdapp-merchant`
 - Demo: `cargo run -p kdapp-merchant -- demo`
   - Creates a new episode (merchant key), then CreateInvoice → MarkPaid → AckReceipt
+- Proxy listener: `cargo run -p kdapp-merchant -- proxy --merchant-private-key <hex> [--wrpc-url wss://host:port]`
 
 CLI subcommands (M0)
 - `demo` — run the default in-process demo.
-- `router-udp --bind 127.0.0.1:9530` — start the UDP TLV router.
+- `router-udp --bind 127.0.0.1:9530 [--proxy]` — start the UDP TLV router (optionally forwarding via proxy channel).
+- `proxy [--merchant-private-key <hex>]` — connect to a Kaspa node and stream accepted txs via `kdapp::proxy::run_listener`.
 - `new --episode-id <u32> [--merchant-private-key <hex>]` — create episode with merchant pubkey.
 - `create --episode-id <u32> --invoice-id <u64> --amount <u64> [--memo <str>] [--merchant-private-key <hex>]` — signed.
 - `pay --episode-id <u32> --invoice-id <u64>` — unsigned (demo).
@@ -44,8 +46,11 @@ Episode API
 - Rollbacks mirror each action for DAG reorg safety.
 - MarkPaid performs coarse validation using tx_outputs in PayloadMetadata when provided by the proxy (>= amount check).
 
-Routing (future)
-- Add a unique PrefixType and 10-bit PatternType when wiring to real proxy::run_listener.
+Routing
+- Each merchant instance derives a deterministic `PrefixType` and 10-bit `PatternType` from its public key:
+  - `prefix = SHA256("onlyKAS:routing" || merchant_pk)[0..4]` (little‑endian u32)
+  - `pattern = [(d[4+i], d[14+i] & 1); i=0..9]` where `d` is the same hash
+- Override with `--prefix <u32>` and `--pattern "p:b,..."` if needed.
 - Off-chain path: use TLV to carry serialized EpisodeMessage; watchers can checkpoint periodically on-chain.
 
 Notes

--- a/examples/kdapp-merchant/src/program_id.rs
+++ b/examples/kdapp-merchant/src/program_id.rs
@@ -1,4 +1,4 @@
-use kdapp::pki::PubKey;
+use kdapp::{generator::{PatternType, PrefixType}, pki::PubKey};
 use sha2::{Digest, Sha256};
 
 /// Derive a deterministic 32-byte label for this merchant program.
@@ -12,5 +12,28 @@ pub fn derive_program_label(merchant: &PubKey, label: &str) -> [u8; 32] {
     let mut arr = [0u8; 32];
     arr.copy_from_slice(&out);
     arr
+}
+
+/// Derive a unique `PrefixType` and 10-bit `PatternType` from the merchant
+/// public key. This keeps routing identifiers deterministic per merchant
+/// instance while remaining reproducible across restarts.
+pub fn derive_routing_ids(merchant: &PubKey) -> (PrefixType, PatternType) {
+    let mut hasher = Sha256::new();
+    hasher.update(b"onlyKAS:routing");
+    hasher.update(merchant.0.serialize());
+    let digest = hasher.finalize();
+
+    // First 4 bytes become the prefix
+    let prefix = PrefixType::from_le_bytes([digest[0], digest[1], digest[2], digest[3]]);
+
+    // Next 20 bytes derive 10 (pos, bit) pairs
+    let mut pattern = [(0u8, 0u8); 10];
+    for i in 0..10 {
+        let pos = digest[4 + i];
+        let bit = digest[14 + i] & 1;
+        pattern[i] = (pos, bit);
+    }
+
+    (prefix, pattern)
 }
 

--- a/examples/kdapp-merchant/src/udp_router.rs
+++ b/examples/kdapp-merchant/src/udp_router.rs
@@ -8,18 +8,21 @@ use kdapp::engine::EngineMsg;
 use kdapp::episode::TxOutputInfo;
 use log::{info, warn};
 
-use crate::tlv::{MsgType, TlvMsg, TLV_VERSION};
+use crate::{
+    sim_router::EngineChannel,
+    tlv::{MsgType, TlvMsg, TLV_VERSION},
+};
 
 /// Minimal UDP TLV router for off-chain delivery.
 /// Accepts TLV messages carrying serialized `EpisodeMessage<ReceiptEpisode>` payloads
 /// and forwards them to the engine as synthetic block-accepted events.
 pub struct UdpRouter {
     last_seq: Arc<Mutex<HashMap<u64, u64>>>,
-    sender: std::sync::mpsc::Sender<EngineMsg>,
+    sender: EngineChannel,
 }
 
 impl UdpRouter {
-    pub fn new(sender: std::sync::mpsc::Sender<EngineMsg>) -> Self {
+    pub fn new(sender: EngineChannel) -> Self {
         Self { last_seq: Arc::new(Mutex::new(HashMap::new())), sender }
     }
 


### PR DESCRIPTION
## Summary
- derive deterministic routing prefix/pattern from merchant key
- add proxy listener mode and CLI options for network/prefix/pattern
- allow routers to target engine locally or via proxy channel
- document merchant routing identifiers and new options

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_68b756b827b0832ba425fa5ce3b7843c