### PR TITLE
feat: add customer registry and payer validation

### DIFF
--- a/examples/kdapp-merchant/onlyKAS-merchant.md
+++ b/examples/kdapp-merchant/onlyKAS-merchant.md
@@ -29,9 +29,11 @@ CLI subcommands (M0)
 - `proxy [--merchant-private-key <hex>]` — connect to a Kaspa node and stream accepted txs via `kdapp::proxy::run_listener`.
 - `new --episode-id <u32> [--merchant-private-key <hex>]` — create episode with merchant pubkey.
 - `create --episode-id <u32> --invoice-id <u64> --amount <u64> [--memo <str>] [--merchant-private-key <hex>]` — signed.
-- `pay --episode-id <u32> --invoice-id <u64>` — unsigned (demo).
+- `pay --episode-id <u32> --invoice-id <u64> --payer-public-key <hex>` — unsigned (demo).
 - `ack --episode-id <u32> --invoice-id <u64> [--merchant-private-key <hex>]` — signed.
 - `cancel --episode-id <u32> --invoice-id <u64>` — unsigned (demo).
+- `register-customer [--customer-private-key <hex>]` — add customer keypair to storage.
+- `list-customers` — show registered customer pubkeys and invoice ids.
 
 Notes
 - For signed commands, pass `--merchant-private-key <hex>` so the pubkey matches the episode’s participant list. Otherwise, a fresh keypair is generated for the process which won’t match previous runs.

--- a/kdapp/src/pki.rs
+++ b/kdapp/src/pki.rs
@@ -21,6 +21,18 @@ impl std::fmt::Display for PubKey {
     }
 }
 
+impl Ord for PubKey {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.serialize().cmp(&other.0.serialize())
+    }
+}
+
+impl PartialOrd for PubKey {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Sig(pub Signature);
 impl BorshSerialize for PubKey {


### PR DESCRIPTION
## Summary
- extend `ReceiptEpisode` with customer mapping and payer verification
- store customer records via sled storage
- add CLI commands for customer registration and listing

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_68b7cb0717f4832b9759098820358a8f