### PR TITLE
feat(merchant): add subscription scheduling support

### DIFF
--- a/examples/kdapp-merchant/src/scheduler.rs
+++ b/examples/kdapp-merchant/src/scheduler.rs
@@ -1,0 +1,30 @@
+use std::sync::mpsc::Sender;
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use kdapp::engine::EpisodeMessage;
+
+use crate::episode::{MerchantCommand, ReceiptEpisode};
+use crate::storage;
+
+fn now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_else(|_| Duration::from_secs(0))
+        .as_secs()
+}
+
+pub fn start(tx: Sender<EpisodeMessage<ReceiptEpisode>>, episode_id: u32) {
+    thread::spawn(move || loop {
+        let current = now();
+        let subs = storage::load_subscriptions();
+        for (id, sub) in subs {
+            if sub.next_run <= current {
+                let cmd = MerchantCommand::ProcessSubscription { subscription_id: id };
+                let msg = EpisodeMessage::UnsignedCommand { episode_id, cmd };
+                let _ = tx.send(msg);
+            }
+        }
+        thread::sleep(Duration::from_secs(10));
+    });
+}


### PR DESCRIPTION
## Summary
- support recurring subscriptions with create/process/cancel commands
- persist subscription metadata and next run timestamps
- add simple scheduler thread to emit `ProcessSubscription` commands
- extend merchant CLI to manage subscriptions and show customer mappings

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_68b7cf18f040832ba99ed19a1dadb6e3