### PR TITLE
Add merchant subscription integration tests and docs

### DIFF
--- a/examples/kdapp-merchant/tests/fixtures.rs
+++ b/examples/kdapp-merchant/tests/fixtures.rs
@@ -1,0 +1,54 @@
+#[path = "../src/episode.rs"]
+pub mod episode;
+#[path = "../src/storage.rs"]
+pub mod storage;
+
+use episode::{CustomerInfo, MerchantCommand, ReceiptEpisode};
+use kdapp::episode::PayloadMetadata;
+use kdapp::pki::{generate_keypair, PubKey};
+use kaspa_consensus_core::Hash;
+
+/// Test context containing a merchant episode with one registered customer.
+pub struct TestContext {
+    pub episode: ReceiptEpisode,
+    pub merchant: PubKey,
+    pub customer: PubKey,
+    pub metadata: PayloadMetadata,
+}
+
+/// Initialize sled storage and create a fresh episode with a merchant and customer.
+pub fn setup() -> TestContext {
+    // ensure a clean database for each test run
+    let _ = std::fs::remove_dir_all("merchant.db");
+    storage::init();
+
+    let (_sk_m, merchant_pk) = generate_keypair();
+    let (_sk_c, customer_pk) = generate_keypair();
+    storage::put_customer(&customer_pk, &CustomerInfo::default());
+
+    let metadata = PayloadMetadata {
+        accepting_hash: Hash::default(),
+        accepting_daa: 0,
+        accepting_time: 1,
+        tx_id: Hash::default(),
+        tx_outputs: None,
+    };
+
+    let episode = ReceiptEpisode::initialize(vec![merchant_pk], &metadata);
+
+    TestContext { episode, merchant: merchant_pk, customer: customer_pk, metadata }
+}
+
+/// Helper for creating a subscription in tests.
+pub fn create_subscription(ctx: &mut TestContext, id: u64, amount: u64, interval: u64) {
+    let cmd = MerchantCommand::CreateSubscription {
+        subscription_id: id,
+        customer: ctx.customer,
+        amount,
+        interval,
+    };
+    ctx
+        .episode
+        .execute(&cmd, Some(ctx.merchant), &ctx.metadata)
+        .expect("create subscription");
+}

--- a/examples/kdapp-merchant/tests/subscriptions.rs
+++ b/examples/kdapp-merchant/tests/subscriptions.rs
@@ -1,0 +1,66 @@
+mod fixtures;
+use fixtures::{create_subscription, episode::{MerchantCommand, MerchantError}, setup};
+use kdapp::episode::EpisodeError;
+
+#[test]
+fn subscription_creation_and_recurring_charges() {
+    let mut ctx = setup();
+    create_subscription(&mut ctx, 1, 100, 10);
+    let next = ctx.metadata.accepting_time + 10;
+    assert_eq!(ctx.episode.subscriptions.get(&1).unwrap().next_run, next);
+
+    // process twice to simulate recurring charges
+    let mut md = ctx.metadata.clone();
+    md.accepting_time = next;
+    ctx
+        .episode
+        .execute(&MerchantCommand::ProcessSubscription { subscription_id: 1 }, None, &md)
+        .expect("process once");
+    assert_eq!(ctx.episode.subscriptions.get(&1).unwrap().next_run, next + 10);
+
+    md.accepting_time = next + 10;
+    ctx
+        .episode
+        .execute(&MerchantCommand::ProcessSubscription { subscription_id: 1 }, None, &md)
+        .expect("process twice");
+    assert_eq!(ctx.episode.subscriptions.get(&1).unwrap().next_run, next + 20);
+}
+
+#[test]
+fn subscription_failure_paths() {
+    let mut ctx = setup();
+
+    // creating two subscriptions with the same id should fail
+    create_subscription(&mut ctx, 2, 50, 5);
+    let err = ctx
+        .episode
+        .execute(
+            &MerchantCommand::CreateSubscription {
+                subscription_id: 2,
+                customer: ctx.customer,
+                amount: 50,
+                interval: 5,
+            },
+            Some(ctx.merchant),
+            &ctx.metadata,
+        )
+        .unwrap_err();
+    match err {
+        EpisodeError::InvalidCommand(MerchantError::SubscriptionExists) => {}
+        _ => panic!("expected duplicate subscription error"),
+    }
+
+    // processing a non-existent subscription should fail
+    let err = ctx
+        .episode
+        .execute(
+            &MerchantCommand::ProcessSubscription { subscription_id: 999 },
+            None,
+            &ctx.metadata,
+        )
+        .unwrap_err();
+    match err {
+        EpisodeError::InvalidCommand(MerchantError::SubscriptionNotFound) => {}
+        _ => panic!("expected missing subscription error"),
+    }
+}


### PR DESCRIPTION
## Summary
- test subscription creation, processing, and error handling
- document subscription commands, TCP router, and sled storage in onlyKAS-merchant

## Testing
- `cargo test -p kdapp-merchant --test subscriptions`


------
https://chatgpt.com/codex/tasks/task_e_68b7d9d19aec832bb4fd4a7cfb5b72cf