### PR TITLE
feat: add kdapp-customer example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "examples/kdapp-indexer",
     "examples/kas-draw",
     "examples/kdapp-merchant",
+    "examples/kdapp-customer",
 ]
 
 

--- a/examples/kdapp-customer/Cargo.toml
+++ b/examples/kdapp-customer/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "kdapp-customer"
+version = "0.0.1"
+edition = "2021"
+publish = false
+
+[dependencies]
+kdapp = { path = "../../kdapp" }
+borsh = { workspace = true }
+secp256k1 = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+tokio = { workspace = true, features = ["rt", "macros", "rt-multi-thread"] }
+env_logger = { workspace = true }
+log = { workspace = true }
+blake2 = "0.10"
+faster-hex = { workspace = true }
+reqwest = { version = "0.12", features = ["json"] }
+serde = { workspace = true, features = ["derive"] }

--- a/examples/kdapp-customer/README.md
+++ b/examples/kdapp-customer/README.md
@@ -1,0 +1,27 @@
+# kdapp-customer
+
+Command line demo for interacting with the merchant receipt episode.
+
+## Subcommands
+
+- `list` – fetch invoices from a running merchant HTTP server.
+- `pay` – send a TLV `MarkPaid` command.
+- `ack` – send a TLV `AckReceipt` command.
+
+## Required arguments
+
+`pay` and `ack` require:
+
+- `--episode-id <id>` – numeric episode identifier.
+- `--invoice-id <id>` – invoice to act on.
+- A signing key:
+  - `pay` uses `--payer-private-key <hex>`.
+  - `ack` uses `--merchant-private-key <hex>`.
+
+The `list` command uses HTTP and does not require these fields.
+
+## Example
+
+```sh
+cargo run -p kdapp-customer -- pay --episode-id 42 --invoice-id 1 --payer-private-key <hex>
+```

--- a/examples/kdapp-customer/src/client_sender.rs
+++ b/examples/kdapp-customer/src/client_sender.rs
@@ -1,0 +1,45 @@
+use std::net::UdpSocket;
+use std::time::Duration;
+
+use kdapp::engine::EpisodeMessage;
+
+use crate::episode::ReceiptEpisode;
+use crate::tlv::{MsgType, TlvMsg, TLV_VERSION};
+
+pub fn send_with_retry(dest: &str, mut tlv: TlvMsg, key: &[u8]) {
+    tlv.sign(key);
+    let sock = UdpSocket::bind("0.0.0.0:0").expect("bind sender");
+    let expected = MsgType::Ack as u8;
+    let bytes = tlv.encode();
+    let mut timeout_ms = 300u64;
+    for attempt in 0..3 {
+        let _ = sock.send_to(&bytes, dest);
+        let _ = sock.set_read_timeout(Some(Duration::from_millis(timeout_ms)));
+        let mut buf = [0u8; 1024];
+        if let Ok((n, _)) = sock.recv_from(&mut buf) {
+            if let Some(ack) = TlvMsg::decode(&buf[..n]) {
+                if ack.msg_type == expected && ack.episode_id == tlv.episode_id && ack.seq == tlv.seq && ack.verify(key) {
+                    println!("ack received for ep {} seq {}", tlv.episode_id, tlv.seq);
+                    return;
+                }
+            }
+        }
+        timeout_ms = timeout_ms.saturating_mul(2);
+        if attempt < 2 {
+            println!("ack timeout, retrying (attempt {} of 3)", attempt + 2);
+        }
+    }
+    eprintln!("ack failed for ep {} seq {}", tlv.episode_id, tlv.seq);
+}
+
+pub fn send_cmd(dest: &str, episode_id: u64, seq: u64, msg: EpisodeMessage<ReceiptEpisode>, key: &[u8]) {
+    let payload = borsh::to_vec(&msg).expect("serialize cmd");
+    let tlv = TlvMsg { version: TLV_VERSION, msg_type: MsgType::Cmd as u8, episode_id, seq, state_hash: [0u8; 32], payload, auth: [0u8; 32] };
+    send_with_retry(dest, tlv, key);
+}
+
+pub fn send_new(dest: &str, episode_id: u64, seq: u64, msg: EpisodeMessage<ReceiptEpisode>, key: &[u8]) {
+    let payload = borsh::to_vec(&msg).expect("serialize new");
+    let tlv = TlvMsg { version: TLV_VERSION, msg_type: MsgType::New as u8, episode_id, seq, state_hash: [0u8; 32], payload, auth: [0u8; 32] };
+    send_with_retry(dest, tlv, key);
+}

--- a/examples/kdapp-customer/src/episode.rs
+++ b/examples/kdapp-customer/src/episode.rs
@@ -1,0 +1,35 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+use kdapp::episode::{Episode, EpisodeError, PayloadMetadata};
+use kdapp::pki::PubKey;
+
+#[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
+pub enum MerchantCommand {
+    MarkPaid { invoice_id: u64, payer: PubKey },
+    AckReceipt { invoice_id: u64 },
+}
+
+#[derive(Clone, Debug, BorshSerialize, BorshDeserialize)]
+pub struct ReceiptEpisode;
+
+impl Episode for ReceiptEpisode {
+    type Command = MerchantCommand;
+    type CommandRollback = (); 
+    type CommandError = (); 
+
+    fn initialize(_participants: Vec<PubKey>, _metadata: &PayloadMetadata) -> Self {
+        Self
+    }
+
+    fn execute(
+        &mut self,
+        _cmd: &Self::Command,
+        _authorization: Option<PubKey>,
+        _metadata: &PayloadMetadata,
+    ) -> Result<Self::CommandRollback, EpisodeError<Self::CommandError>> {
+        Ok(())
+    }
+
+    fn rollback(&mut self, _rollback: Self::CommandRollback) -> bool {
+        true
+    }
+}

--- a/examples/kdapp-customer/src/main.rs
+++ b/examples/kdapp-customer/src/main.rs
@@ -1,0 +1,115 @@
+mod client_sender;
+mod tlv;
+mod episode;
+
+use clap::{Parser, Subcommand};
+use kdapp::engine::EpisodeMessage;
+use kdapp::pki::PubKey;
+use episode::{MerchantCommand, ReceiptEpisode};
+use secp256k1::{Secp256k1, SecretKey};
+use serde::Deserialize;
+
+use client_sender::{send_cmd, send_new};
+use tlv::DEMO_HMAC_KEY;
+
+#[derive(Parser, Debug)]
+#[command(name = "kdapp-customer", about = "Interact with merchant invoices")]
+struct Args {
+    #[arg(long, default_value = "127.0.0.1:9530")]
+    dest: String,
+    #[arg(long, default_value = "http://127.0.0.1:3000")]
+    server: String,
+    #[arg(long)]
+    api_key: Option<String>,
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// List invoices via HTTP
+    List,
+    /// Pay an invoice using TLV transport
+    Pay {
+        #[arg(long)]
+        episode_id: u32,
+        #[arg(long)]
+        invoice_id: u64,
+        #[arg(long)]
+        payer_private_key: String,
+    },
+    /// Acknowledge a paid invoice using TLV transport
+    Ack {
+        #[arg(long)]
+        episode_id: u32,
+        #[arg(long)]
+        invoice_id: u64,
+        #[arg(long)]
+        merchant_private_key: String,
+    },
+}
+
+#[derive(Deserialize)]
+struct InvoiceOut {
+    id: u64,
+    amount: u64,
+    memo: Option<String>,
+    status: String,
+    payer: Option<String>,
+    created_at: u64,
+    last_update: u64,
+}
+
+fn parse_secret_key(hex: &str) -> Option<SecretKey> {
+    let mut buf = [0u8; 32];
+    let mut tmp = vec![0u8; hex.len() / 2 + hex.len() % 2];
+    if faster_hex::hex_decode(hex.as_bytes(), &mut tmp).is_ok() && tmp.len() == 32 {
+        buf.copy_from_slice(&tmp);
+        SecretKey::from_slice(&buf).ok()
+    } else {
+        None
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    let args = Args::parse();
+    match args.command {
+        Command::List => {
+            let client = reqwest::Client::new();
+            let mut req = client.get(format!("{}/invoices", args.server));
+            if let Some(key) = args.api_key.as_deref() {
+                req = req.header("x-api-key", key);
+            }
+            match req.send().await.and_then(|r| r.json::<Vec<InvoiceOut>>().await) {
+                Ok(invoices) => {
+                    for inv in invoices {
+                        println!("invoice {} amount {} status {}", inv.id, inv.amount, inv.status);
+                    }
+                }
+                Err(e) => eprintln!("list failed: {e}"),
+            }
+        }
+        Command::Pay { episode_id, invoice_id, payer_private_key } => {
+            let sk = parse_secret_key(&payer_private_key).expect("invalid private key");
+            let secp = Secp256k1::new();
+            let pk = PubKey(secp256k1::PublicKey::from_secret_key(&secp, &sk));
+            let new_msg = EpisodeMessage::<ReceiptEpisode>::NewEpisode { episode_id, participants: vec![pk] };
+            send_new(&args.dest, episode_id as u64, 0, new_msg, DEMO_HMAC_KEY);
+            let cmd = MerchantCommand::MarkPaid { invoice_id, payer: pk };
+            let msg = EpisodeMessage::new_signed_command(episode_id, cmd, sk, pk);
+            send_cmd(&args.dest, episode_id as u64, 1, msg, DEMO_HMAC_KEY);
+        }
+        Command::Ack { episode_id, invoice_id, merchant_private_key } => {
+            let sk = parse_secret_key(&merchant_private_key).expect("invalid private key");
+            let secp = Secp256k1::new();
+            let pk = PubKey(secp256k1::PublicKey::from_secret_key(&secp, &sk));
+            let new_msg = EpisodeMessage::<ReceiptEpisode>::NewEpisode { episode_id, participants: vec![pk] };
+            send_new(&args.dest, episode_id as u64, 0, new_msg, DEMO_HMAC_KEY);
+            let cmd = MerchantCommand::AckReceipt { invoice_id };
+            let msg = EpisodeMessage::new_signed_command(episode_id, cmd, sk, pk);
+            send_cmd(&args.dest, episode_id as u64, 1, msg, DEMO_HMAC_KEY);
+        }
+    }
+}

--- a/examples/kdapp-customer/src/tlv.rs
+++ b/examples/kdapp-customer/src/tlv.rs
@@ -1,0 +1,113 @@
+use blake2::{Blake2b512, Digest};
+
+pub const DEMO_HMAC_KEY: &[u8] = b"kdapp-demo-secret";
+
+pub const TLV_VERSION: u8 = 1;
+
+#[derive(Clone, Copy)]
+#[repr(u8)]
+pub enum MsgType {
+    New = 0,
+    Cmd = 1,
+    Ack = 2,
+    Close = 3,
+    AckClose = 4,
+    Checkpoint = 5,
+    Handshake = 6,
+}
+
+impl MsgType {
+    pub fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            0 => Some(MsgType::New),
+            1 => Some(MsgType::Cmd),
+            2 => Some(MsgType::Ack),
+            3 => Some(MsgType::Close),
+            4 => Some(MsgType::AckClose),
+            5 => Some(MsgType::Checkpoint),
+            6 => Some(MsgType::Handshake),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct TlvMsg {
+    pub version: u8,
+    pub msg_type: u8,
+    pub episode_id: u64,
+    pub seq: u64,
+    pub state_hash: [u8; 32],
+    pub payload: Vec<u8>,
+    pub auth: [u8; 32],
+}
+
+impl TlvMsg {
+    fn bytes_for_sign(&self) -> Vec<u8> {
+        let mut v = Vec::with_capacity(1 + 1 + 8 + 8 + 32 + 2 + self.payload.len());
+        v.push(self.version);
+        v.push(self.msg_type);
+        v.extend_from_slice(&self.episode_id.to_le_bytes());
+        v.extend_from_slice(&self.seq.to_le_bytes());
+        v.extend_from_slice(&self.state_hash);
+        let len: u16 = self.payload.len() as u16;
+        v.extend_from_slice(&len.to_le_bytes());
+        v.extend_from_slice(&self.payload);
+        v
+    }
+
+    pub fn sign(&mut self, key: &[u8]) {
+        let mut h = Blake2b512::new_with_prefix(key);
+        h.update(self.bytes_for_sign());
+        let out = h.finalize();
+        self.auth.copy_from_slice(&out[..32]);
+    }
+
+    pub fn verify(&self, key: &[u8]) -> bool {
+        let mut h = Blake2b512::new_with_prefix(key);
+        h.update(self.bytes_for_sign());
+        let out = h.finalize();
+        self.auth == out[..32]
+    }
+
+    pub fn encode(&self) -> Vec<u8> {
+        let mut v = self.bytes_for_sign();
+        v.extend_from_slice(&self.auth);
+        v
+    }
+
+    pub fn decode(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < 1 + 1 + 8 + 8 + 32 + 2 + 32 {
+            return None;
+        }
+        let version = bytes[0];
+        let msg_type = bytes[1];
+        if version != TLV_VERSION {
+            return None;
+        }
+        MsgType::from_u8(msg_type)?;
+        let episode_id = u64::from_le_bytes(bytes[2..10].try_into().ok()?);
+        let seq = u64::from_le_bytes(bytes[10..18].try_into().ok()?);
+        let mut state_hash = [0u8; 32];
+        state_hash.copy_from_slice(&bytes[18..50]);
+        let payload_len = u16::from_le_bytes(bytes[50..52].try_into().ok()?);
+        if bytes.len() < 52 + payload_len as usize + 32 {
+            return None;
+        }
+        let payload_start = 52;
+        let payload_end = payload_start + payload_len as usize;
+        let payload = bytes[payload_start..payload_end].to_vec();
+        let mut auth = [0u8; 32];
+        auth.copy_from_slice(&bytes[payload_end..payload_end + 32]);
+        Some(Self { version, msg_type, episode_id, seq, state_hash, payload, auth })
+    }
+}
+
+pub fn hash_state(bytes: &[u8]) -> [u8; 32] {
+    let mut h = Blake2b512::new();
+    h.update(bytes);
+    let out = h.finalize();
+    let mut arr = [0u8; 32];
+    arr.copy_from_slice(&out[..32]);
+    arr
+}


### PR DESCRIPTION
## Summary
- add `kdapp-customer` CLI example with subcommands to list, pay, and acknowledge invoices
- use TLV transport via `send_new`/`send_cmd`
- document required arguments in README

## Testing
- No tests were run due to repository restrictions

------
https://chatgpt.com/codex/tasks/task_e_68bd4c356ac4832bb0cd6b022fd47889