### PR TITLE
feat: guardian dispute escalation and refund co-signing

### DIFF
--- a/examples/kdapp-guardian/README.md
+++ b/examples/kdapp-guardian/README.md
@@ -39,3 +39,19 @@ guardian and periodically sends `Confirm` messages referencing the
 latest checkpoint sequence. If a customer detects a problem it may
 send an `Escalate` message which causes the guardian to verify the
 latest checkpoint and co‑sign a refund or release transaction.
+
+## Dispute flow example
+
+1. The merchant observes a conflicting payment and forwards a dispute:
+
+   ```rust
+   guardian::send_escalate("127.0.0.1:9650", 1, "payment dispute".into(), refund_tx.clone(), guardian::DEMO_HMAC_KEY);
+   ```
+
+2. The guardian's watcher detects the next `OKCP` anchor and notices a
+   gap in the sequence, recording an open dispute in `GuardianState`.
+
+3. When the `Escalate` message arrives the guardian verifies the
+   checkpoint and signs the provided refund transaction using the
+   demo keypair. The merchant can then broadcast the refund once the
+   signature is verified.

--- a/examples/kdapp-merchant/src/tlv.rs
+++ b/examples/kdapp-merchant/src/tlv.rs
@@ -16,6 +16,7 @@ pub enum MsgType {
     AckClose = 4,
     Checkpoint = 5,
     Handshake = 6,
+    Refund = 7,
 }
 
 impl MsgType {
@@ -28,6 +29,7 @@ impl MsgType {
             4 => Some(MsgType::AckClose),
             5 => Some(MsgType::Checkpoint),
             6 => Some(MsgType::Handshake),
+            7 => Some(MsgType::Refund),
             _ => None,
         }
     }

--- a/examples/kdapp-merchant/tests/invoice_flow.rs
+++ b/examples/kdapp-merchant/tests/invoice_flow.rs
@@ -53,7 +53,7 @@ fn invoice_flow_with_guardian() {
         assert!(matches!(msg2, GuardianMsg::Confirm { episode_id: 1, seq: 7 }));
         state
     });
-    send_escalate(&addr.to_string(), 1, "late payment".into(), DEMO_HMAC_KEY);
+    send_escalate(&addr.to_string(), 1, "late payment".into(), vec![], DEMO_HMAC_KEY);
     send_confirm(&addr.to_string(), 1, 7, DEMO_HMAC_KEY);
     let state = handle.join().unwrap();
     assert_eq!(state.observed_payments, vec![1]);


### PR DESCRIPTION
## Summary
- track checkpoint discrepancies and sign refunds in guardian state
- forward merchant disputes to guardians and verify co-signatures
- add watcher logic for guardian-signed refunds and document dispute flow

## Testing
- ⚠️ `cargo test --workspace` *(skipped: repository guidelines prohibit running cargo commands)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0b8702ec832b9bd0f099217876d6