### PR TITLE
feat: propagate guardian keys through merchant receipts

### DIFF
--- a/examples/kdapp-merchant/src/server.rs
+++ b/examples/kdapp-merchant/src/server.rs
@@ -79,6 +79,7 @@ struct CreateInvoiceReq {
     invoice_id: u64,
     amount: u64,
     memo: Option<String>,
+    guardian_public_keys: Option<Vec<String>>,
 }
 
 async fn create_invoice(
@@ -87,7 +88,13 @@ async fn create_invoice(
     Json(req): Json<CreateInvoiceReq>,
 ) -> Result<StatusCode, StatusCode> {
     authorize(&headers, &state)?;
-    let cmd = MerchantCommand::CreateInvoice { invoice_id: req.invoice_id, amount: req.amount, memo: req.memo };
+    let gkeys = req
+        .guardian_public_keys
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|h| parse_public_key(h))
+        .collect();
+    let cmd = MerchantCommand::CreateInvoice { invoice_id: req.invoice_id, amount: req.amount, memo: req.memo, guardian_keys: gkeys };
     let msg = EpisodeMessage::new_signed_command(state.episode_id, cmd, state.merchant_sk, state.merchant_pk);
     state.router.forward::<ReceiptEpisode>(msg);
     Ok(StatusCode::ACCEPTED)

--- a/examples/kdapp-merchant/tests/invoice_flow.rs
+++ b/examples/kdapp-merchant/tests/invoice_flow.rs
@@ -17,9 +17,9 @@ fn invoice_flow_with_guardian() {
     let mut ctx = setup();
     let mut customer = CustomerEpisode::initialize(vec![ctx.customer], &ctx.metadata);
 
-    let create = MerchantCommand::CreateInvoice { invoice_id: 1, amount: 100, memo: Some("coffee".into()) };
+    let create = MerchantCommand::CreateInvoice { invoice_id: 1, amount: 100, memo: Some("coffee".into()), guardian_keys: vec![] };
     ctx.episode.execute(&create, Some(ctx.merchant), &ctx.metadata).expect("merchant create");
-    let c_create = CustomerCommand::CreateInvoice { invoice_id: 1, amount: 100, memo: Some("coffee".into()) };
+    let c_create = CustomerCommand::CreateInvoice { invoice_id: 1, amount: 100, memo: Some("coffee".into()), guardian_keys: vec![] };
     customer.execute(&c_create, Some(ctx.merchant), &ctx.metadata).expect("customer create");
 
     let script = {
@@ -65,9 +65,9 @@ fn replay_attack_rejected() {
     let mut ctx = setup();
     let mut customer = CustomerEpisode::initialize(vec![ctx.customer], &ctx.metadata);
     for id in [1, 2] {
-        let cmd = MerchantCommand::CreateInvoice { invoice_id: id, amount: 50, memo: None };
+        let cmd = MerchantCommand::CreateInvoice { invoice_id: id, amount: 50, memo: None, guardian_keys: vec![] };
         ctx.episode.execute(&cmd, Some(ctx.merchant), &ctx.metadata).unwrap();
-        let c_cmd = CustomerCommand::CreateInvoice { invoice_id: id, amount: 50, memo: None };
+        let c_cmd = CustomerCommand::CreateInvoice { invoice_id: id, amount: 50, memo: None, guardian_keys: vec![] };
         customer.execute(&c_cmd, Some(ctx.merchant), &ctx.metadata).unwrap();
     }
     let script = {
@@ -92,9 +92,9 @@ fn replay_attack_rejected() {
 fn incorrect_payment_amount_rejected() {
     let mut ctx = setup();
     let mut customer = CustomerEpisode::initialize(vec![ctx.customer], &ctx.metadata);
-    let create = MerchantCommand::CreateInvoice { invoice_id: 3, amount: 100, memo: None };
+    let create = MerchantCommand::CreateInvoice { invoice_id: 3, amount: 100, memo: None, guardian_keys: vec![] };
     ctx.episode.execute(&create, Some(ctx.merchant), &ctx.metadata).unwrap();
-    let c_create = CustomerCommand::CreateInvoice { invoice_id: 3, amount: 100, memo: None };
+    let c_create = CustomerCommand::CreateInvoice { invoice_id: 3, amount: 100, memo: None, guardian_keys: vec![] };
     customer.execute(&c_create, Some(ctx.merchant), &ctx.metadata).unwrap();
     let script = {
         let mut s = Vec::with_capacity(35);


### PR DESCRIPTION
## Summary
- allow merchants to include guardian keys on receipts and propagate them through invoices
- handshake with and notify all guardians listed on an episode
- expose repeatable `--guardian-addr`/`--guardian-key` flags in merchant and customer CLIs

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68bf1cb90984832b85e2d81ad2f0b701