### PR TITLE
feat(guardian): track message sequences with metrics

### DIFF
--- a/examples/kdapp-guardian/src/metrics.rs
+++ b/examples/kdapp-guardian/src/metrics.rs
@@ -1,0 +1,22 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+pub static VALID: AtomicU64 = AtomicU64::new(0);
+pub static INVALID: AtomicU64 = AtomicU64::new(0);
+
+pub fn inc_valid() {
+    VALID.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn inc_invalid() {
+    INVALID.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn snapshot() -> (u64, u64) {
+    (VALID.load(Ordering::Relaxed), INVALID.load(Ordering::Relaxed))
+}
+
+#[cfg(test)]
+pub fn reset() {
+    VALID.store(0, Ordering::Relaxed);
+    INVALID.store(0, Ordering::Relaxed);
+}


### PR DESCRIPTION
## Summary
- Track per-episode sequence numbers in GuardianState to reject replays and out-of-order messages
- Add structured logging for handshake, escalation, confirmation, and replay detection
- Expose basic valid/invalid message counters via a metrics module and expand guardian tests

## Testing
- ⚠️ `cargo fmt --all` *(not run)*
- ⚠️ `cargo clippy --workspace --all-targets -- -D warnings` *(not run)*
- ⚠️ `cargo test --workspace` *(not run)*

------
https://chatgpt.com/codex/tasks/task_e_68bf234d973c832ba6144d2ecb4edeac