### PR TITLE
feat: add config-driven guardian service

### DIFF
--- a/examples/kdapp-guardian/Cargo.toml
+++ b/examples/kdapp-guardian/Cargo.toml
@@ -14,3 +14,12 @@ kaspa-wrpc-client = { workspace = true }
 kaspa-rpc-core = { workspace = true }
 kaspa-consensus-core = { workspace = true }
 secp256k1 = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
+toml = "0.8"
+faster-hex = { workspace = true }
+env_logger = { workspace = true }
+
+[[bin]]
+name = "guardian-service"
+path = "src/main.rs"

--- a/examples/kdapp-guardian/README.md
+++ b/examples/kdapp-guardian/README.md
@@ -5,21 +5,28 @@ anchors and assists merchants and customers during disputes.
 
 ## Running the guardian
 
-The `service::run` helper starts a UDP listener for guardian messages
-and polls the Kaspa virtual chain via RPC to detect on‑chain checkpoint anchors:
+The `guardian-service` binary reads a small TOML configuration file and
+starts a UDP listener for guardian messages while polling the Kaspa
+virtual chain for checkpoint anchors:
 
-```rust
-fn main() {
-    let _state = kdapp_guardian::service::run("127.0.0.1:9650", None);
-    std::thread::park();
-}
+```bash
+guardian-service --config config.toml
+```
+
+An example config:
+
+```toml
+listen_addr = "127.0.0.1:9650"
+wrpc_url = "wss://node:16110"
+mainnet = false
+key_path = "guardian.key"
 ```
 
 Under the hood the service uses `get_block_dag_info` +
-`get_virtual_chain_from_block` to follow accepted blocks and scans
-their merged blocks for compact OKCP records (program prefix `KMCP`).
-The returned `GuardianState` is shared and updated as anchors are
-observed on‑chain.
+`get_virtual_chain_from_block` to follow accepted blocks and scans their
+merged blocks for compact OKCP records (program prefix `KMCP`). The
+returned `GuardianState` is shared and updated as anchors are observed
+on‑chain.
 
 ## Using with merchant and customer
 

--- a/examples/kdapp-guardian/src/main.rs
+++ b/examples/kdapp-guardian/src/main.rs
@@ -1,0 +1,8 @@
+use kdapp_guardian::service::{run, GuardianConfig};
+
+fn main() {
+    env_logger::init();
+    let config = GuardianConfig::from_args();
+    let _state = run(&config);
+    std::thread::park();
+}


### PR DESCRIPTION
## Summary
- add GuardianConfig struct with CLI/TOML parsing
- generate or load guardian key and log public key
- expose guardian-service binary for running the watcher

## Testing
- ⚠️ `cargo fmt --all` (not run)
- ⚠️ `cargo clippy --workspace --all-targets -- -D warnings` (not run)
- ⚠️ `cargo test --workspace` (not run)


------
https://chatgpt.com/codex/tasks/task_e_68bfcdcb8084832ba8553b385b274fd1