### PR TITLE
feat: persist guardian state across restarts

### DIFF
--- a/examples/kdapp-guardian/Cargo.toml
+++ b/examples/kdapp-guardian/Cargo.toml
@@ -19,6 +19,7 @@ serde = { workspace = true, features = ["derive"] }
 toml = "0.8"
 faster-hex = { workspace = true }
 env_logger = { workspace = true }
+serde_json = "1.0"
 
 [[bin]]
 name = "guardian-service"

--- a/examples/kdapp-guardian/README.md
+++ b/examples/kdapp-guardian/README.md
@@ -20,13 +20,15 @@ listen_addr = "127.0.0.1:9650"
 wrpc_url = "wss://node:16110"
 mainnet = false
 key_path = "guardian.key"
+state_path = "guardian_state.json"
 ```
 
 Under the hood the service uses `get_block_dag_info` +
 `get_virtual_chain_from_block` to follow accepted blocks and scans their
 merged blocks for compact OKCP records (program prefix `KMCP`). The
 returned `GuardianState` is shared and updated as anchors are observed
-on‑chain.
+on‑chain. When `state_path` is provided the guardian persists its state
+to disk, allowing disputes and sequence information to survive restarts.
 
 ## Using with merchant and customer
 


### PR DESCRIPTION
## Summary
- add optional `state_path` config and CLI flag for guardian service
- persist `GuardianState` to JSON with atomic writes and reload on startup
- document and test state persistence across restarts

## Testing
- ⚠️ `cargo fmt --all` *(please run)*
- ⚠️ `cargo clippy --workspace --all-targets -- -D warnings` *(please run)*
- ⚠️ `cargo test --workspace` *(please run)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd63df244832b9e16b0ddf02f4e77