### PR TITLE
feat: add HTTP metrics endpoints

### DIFF
--- a/examples/kdapp-guardian/Cargo.toml
+++ b/examples/kdapp-guardian/Cargo.toml
@@ -20,6 +20,7 @@ toml = "0.8"
 faster-hex = { workspace = true }
 env_logger = { workspace = true }
 serde_json = "1.0"
+axum = { version = "0.8", features = ["http1", "json", "tokio"] }
 
 [[bin]]
 name = "guardian-service"

--- a/examples/kdapp-merchant/src/main.rs
+++ b/examples/kdapp-merchant/src/main.rs
@@ -226,6 +226,9 @@ enum CliCmd {
         /// Show current mempool metrics and exit
         #[arg(long, default_value_t = false)]
         show_metrics: bool,
+        /// Serve mempool metrics over HTTP on this port
+        #[arg(long)]
+        http_port: Option<u16>,
     },
     /// Derive a Kaspa address from a compressed secp256k1 public key (hex)
     Addr {
@@ -588,7 +591,7 @@ fn main() {
                 log::info!("on-chain ack submitted: tx_id={tx_id}");
             });
         }
-        CliCmd::Watcher { bind, kaspa_private_key, mainnet, wrpc_url, max_fee, congestion_threshold, show_metrics } => {
+        CliCmd::Watcher { bind, kaspa_private_key, mainnet, wrpc_url, max_fee, congestion_threshold, show_metrics, http_port } => {
             if show_metrics {
                 let network =
                     if mainnet { NetworkId::new(NetworkType::Mainnet) } else { NetworkId::with_suffix(NetworkType::Testnet, 10) };
@@ -611,6 +614,7 @@ fn main() {
                     wrpc_url,
                     max_fee.unwrap_or(u64::MAX),
                     congestion_threshold.unwrap_or(0.7),
+                    http_port,
                 )
                 .expect("watcher");
             }


### PR DESCRIPTION
## Summary
- expose health and metrics endpoints for guardian service
- serve watcher mempool metrics over HTTP with optional port flag

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_68bfe16933ec832b83642fda085e28f2