### PR TITLE
fix(guardian): add shutdown handle

### DIFF
--- a/examples/kdapp-guardian/src/main.rs
+++ b/examples/kdapp-guardian/src/main.rs
@@ -3,6 +3,6 @@ use kdapp_guardian::service::{run, GuardianConfig};
 fn main() {
     env_logger::init();
     let config = GuardianConfig::from_args();
-    let _state = run(&config);
+    let _handle = run(&config);
     std::thread::park();
 }

--- a/examples/tests/guardian_refund.rs
+++ b/examples/tests/guardian_refund.rs
@@ -49,7 +49,8 @@ fn scenario_a_refund_signed_and_recorded() {
         state_path: None,
         watcher_addr: Some(format!("127.0.0.1:{watcher_port}")),
     };
-    let state = run(&cfg);
+    let handle = run(&cfg);
+    let state = handle.state.clone();
 
     let state_watch = state.clone();
     let pk_watch = pk;
@@ -107,6 +108,8 @@ fn scenario_a_refund_signed_and_recorded() {
     let after = metrics::snapshot();
     assert_eq!(after.0, before.0 + 1);
     assert_eq!(after.1, before.1);
+
+    handle.shutdown();
 }
 
 #[test]
@@ -137,7 +140,8 @@ fn scenario_b_replay_confirm_rejected() {
         state_path: None,
         watcher_addr: Some(format!("127.0.0.1:{watcher_port}")),
     };
-    let state = run(&cfg);
+    let handle = run(&cfg);
+    let state = handle.state.clone();
     thread::spawn(move || {
         let sock = watcher;
         let mut buf = [0u8; 1024];
@@ -169,6 +173,8 @@ fn scenario_b_replay_confirm_rejected() {
     assert_eq!(after.0, before.0 + 2);
     assert_eq!(after.1, before.1 + 3);
     assert_eq!(state.lock().unwrap().checkpoints, vec![(ep, 1)]);
+
+    handle.shutdown();
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `ServiceHandle` with shutdown flag for guardian service threads
- allow UDP, wRPC, and HTTP tasks to exit when triggered
- update integration tests to shutdown service after assertions

## Testing
- ⚠️ `cargo test --workspace` (not run: repository policy prevents agents from running cargo commands)


------
https://chatgpt.com/codex/tasks/task_e_68c05cc318b4832b9fc1adfb66ca9bde