### PR TITLE
fix(kdapp-guardian): move shutdown futures into async blocks

### DIFF
--- a/examples/kdapp-guardian/src/service.rs
+++ b/examples/kdapp-guardian/src/service.rs
@@ -358,7 +358,7 @@ pub fn run(config: &GuardianConfig) -> ServiceHandle {
             let network =
                 if mainnet { NetworkId::new(NetworkType::Mainnet) } else { NetworkId::with_suffix(NetworkType::Testnet, 10) };
             if let Ok(client) = proxy::connect_client(network, wrpc_url).await {
-                let shutdown_fut = async {
+                let shutdown_fut = async move {
                     while !shutdown_watch.load(Ordering::Relaxed) {
                         tokio::time::sleep(Duration::from_millis(100)).await;
                     }
@@ -388,7 +388,7 @@ pub fn run(config: &GuardianConfig) -> ServiceHandle {
         let rt = tokio::runtime::Runtime::new().expect("runtime");
         rt.block_on(async move {
             let app = Router::new().route("/healthz", get(healthz)).route("/metrics", get(metrics_endpoint)).with_state(state_http);
-            let shutdown_fut = async {
+            let shutdown_fut = async move {
                 while !shutdown_http.load(Ordering::Relaxed) {
                     tokio::time::sleep(Duration::from_millis(100)).await;
                 }


### PR DESCRIPTION
## Summary
- fix lifetime errors by moving `shutdown_*` flags into their async futures

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68c116c872f8832bb3fda6d7311811af