### PR TITLE
feat(examples): add pluggable watcher fee policy

### DIFF
--- a/examples/kdapp-merchant/src/server.rs
+++ b/examples/kdapp-merchant/src/server.rs
@@ -222,8 +222,11 @@ struct MempoolMetrics {
 }
 
 async fn mempool_metrics() -> Result<Json<MempoolMetrics>, StatusCode> {
-    if let Some((base_fee, congestion)) = watcher::get_metrics() {
-        Ok(Json(MempoolMetrics { base_fee, congestion }))
+    if let Some(snap) = watcher::get_metrics() {
+        Ok(Json(MempoolMetrics {
+            base_fee: snap.base_fee,
+            congestion: snap.congestion_ratio,
+        }))
     } else {
         Err(StatusCode::SERVICE_UNAVAILABLE)
     }


### PR DESCRIPTION
## Summary
- add `FeePolicy` trait with static and congestion-aware implementations
- allow watcher CLI to select and configure fee policy
- expose new mempool snapshot metrics to HTTP server

## Testing
- ⚠️ `cargo fmt --all` (not run: per repository guidelines)
- ⚠️ `cargo clippy --workspace --all-targets -- -D warnings` (not run: per repository guidelines)
- ⚠️ `cargo test --workspace` (not run: per repository guidelines)


------
https://chatgpt.com/codex/tasks/task_e_68c11e820854832bbcb76c20b73b814c