### PR TITLE
feat(examples): add guardian config and key bootstrap

### DIFF
--- a/examples/kdapp-guardian/config.toml
+++ b/examples/kdapp-guardian/config.toml
@@ -5,7 +5,5 @@ wrpc_url = "wss://node:16110"
 mainnet = false
 # Private key file for guardian's ECDSA key; created if missing
 key_path = "guardian.key"
-# Optional: persist guardian state (disputes, signatures)
-state_path = "guardian_state.json"
-## Optional: explicit watcher address (overrides KDAPP_GUARDIAN_WATCHER_ADDR; default 127.0.0.1:9590)
-watcher_addr = "127.0.0.1:9590"
+# Log level for env_logger
+log_level = "info"

--- a/examples/kdapp-guardian/src/main.rs
+++ b/examples/kdapp-guardian/src/main.rs
@@ -1,8 +1,9 @@
+use env_logger::Env;
 use kdapp_guardian::service::{run, GuardianConfig};
 
 fn main() {
-    env_logger::init();
     let config = GuardianConfig::from_args();
+    env_logger::Builder::from_env(Env::default().default_filter_or(&config.log_level)).init();
     let _handle = run(&config);
     std::thread::park();
 }


### PR DESCRIPTION
## Summary
- add `GuardianConfig` with listen address, wRPC URL, mainnet flag, key path and log level
- load or generate guardian key and log public key on startup
- simplify guardian tests for new configuration
- resolve clippy warnings in guardian service

## Testing
- ⚠️ `cargo fmt --all` (skipped: requires user execution)
- ⚠️ `cargo clippy --workspace --all-targets -- -D warnings` (skipped: requires user execution)
- ⚠️ `cargo test --workspace` (skipped: requires user execution)


------
https://chatgpt.com/codex/tasks/task_e_68c120469268832bb47aa45b43364298