### PR TITLE
feat(examples): add guardian config and key bootstrap

### DIFF
--- a/examples/kdapp-merchant/tests/invoice_flow.rs
+++ b/examples/kdapp-merchant/tests/invoice_flow.rs
@@ -47,9 +47,9 @@ fn invoice_flow_with_guardian() {
     let addr = server.local_addr().unwrap();
     let handle = thread::spawn(move || {
         let mut state = GuardianState::default();
-        let msg1 = receive(&server, &mut state, DEMO_HMAC_KEY).unwrap();
+        let (msg1, _) = receive(&server, &mut state, DEMO_HMAC_KEY).unwrap();
         assert!(matches!(msg1, GuardianMsg::Escalate { episode_id: 1, .. }));
-        let msg2 = receive(&server, &mut state, DEMO_HMAC_KEY).unwrap();
+        let (msg2, _) = receive(&server, &mut state, DEMO_HMAC_KEY).unwrap();
         assert!(matches!(msg2, GuardianMsg::Confirm { episode_id: 1, seq: 1 }));
         state
     });


### PR DESCRIPTION
## Summary
- add `GuardianConfig` with listen address, wRPC URL, mainnet flag, key path and log level
- load or generate guardian key and log public key on startup
- simplify guardian tests for new configuration
- resolve clippy warnings in guardian service
- forward signed refunds to escalation sender via UDP

## Testing
- ⚠️ `cargo fmt --all` (skipped: requires user execution)
- ⚠️ `cargo clippy --workspace --all-targets -- -D warnings` (skipped: requires user execution)
- ⚠️ `cargo test --workspace` (skipped: requires user execution)


------
https://chatgpt.com/codex/tasks/task_e_68c131356144832b867db7147de27ab0