### PR TITLE
feat: expose metrics and invoice webhooks

### DIFF
--- a/examples/kdapp-merchant/Cargo.toml
+++ b/examples/kdapp-merchant/Cargo.toml
@@ -26,6 +26,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0"
 axum = { version = "0.8", features = ["http1", "json", "tokio"] }
 kdapp-guardian = { path = "../kdapp-guardian" }
+reqwest = { version = "0.11", features = ["blocking", "json"] }
 
 [dev-dependencies]
 rand = { workspace = true }

--- a/examples/kdapp-merchant/src/handler.rs
+++ b/examples/kdapp-merchant/src/handler.rs
@@ -1,12 +1,16 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::{Mutex, OnceLock};
+use std::thread;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use faster_hex::hex_encode;
 use kdapp::episode::{EpisodeEventHandler, EpisodeId, PayloadMetadata};
 use kdapp::pki::{to_message, verify_signature, PubKey, Sig};
+use reqwest::blocking::Client;
+use serde::Serialize;
 
 use crate::client_sender;
-use crate::episode::{MerchantCommand, ReceiptEpisode};
+use crate::episode::{Invoice, MerchantCommand, ReceiptEpisode};
 use crate::storage;
 use crate::tlv::{hash_state, MsgType, TlvMsg, DEMO_HMAC_KEY, TLV_VERSION};
 use kdapp_guardian::{self as guardian};
@@ -21,6 +25,7 @@ static LAST_CKPT: OnceLock<Mutex<HashMap<EpisodeId, u64>>> = OnceLock::new();
 static DID_HANDSHAKE: OnceLock<()> = OnceLock::new();
 static GUARDIANS: OnceLock<Mutex<Vec<(String, PubKey)>>> = OnceLock::new();
 static GUARDIAN_HANDSHAKES: OnceLock<Mutex<HashSet<PubKey>>> = OnceLock::new();
+static WEBHOOK_URL: OnceLock<Option<String>> = OnceLock::new();
 
 fn now() -> u64 {
     SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs()
@@ -28,6 +33,17 @@ fn now() -> u64 {
 
 pub fn add_guardian(addr: String, pk: PubKey) {
     GUARDIANS.get_or_init(|| Mutex::new(Vec::new())).lock().unwrap().push((addr, pk));
+}
+
+pub fn set_webhook(url: Option<String>) {
+    WEBHOOK_URL.get_or_init(|| url);
+}
+
+fn pk_to_hex(pk: &PubKey) -> String {
+    let bytes = pk.0.serialize();
+    let mut out = vec![0u8; bytes.len() * 2];
+    hex_encode(&bytes, &mut out).expect("hex encode");
+    String::from_utf8(out).expect("utf8")
 }
 
 fn emit_checkpoint(episode_id: EpisodeId, episode: &ReceiptEpisode, force: bool) {
@@ -106,6 +122,36 @@ fn forward_dispute(episode_id: EpisodeId, episode: &ReceiptEpisode) {
     }
 }
 
+#[derive(Serialize)]
+struct InvoiceEvent {
+    id: u64,
+    amount: u64,
+    memo: Option<String>,
+    status: String,
+    payer: Option<String>,
+    created_at: u64,
+    last_update: u64,
+}
+
+fn notify_invoice(inv: &Invoice) {
+    let url = match WEBHOOK_URL.get().and_then(|u| u.clone()) {
+        Some(u) => u,
+        None => return,
+    };
+    let event = InvoiceEvent {
+        id: inv.id,
+        amount: inv.amount,
+        memo: inv.memo.clone(),
+        status: format!("{:?}", inv.status),
+        payer: inv.payer.as_ref().map(pk_to_hex),
+        created_at: inv.created_at,
+        last_update: inv.last_update,
+    };
+    thread::spawn(move || {
+        let _ = Client::new().post(&url).json(&event).send();
+    });
+}
+
 fn verify_guardian_cosign(tx: &[u8], sig: &Sig, gpk: &PubKey) -> bool {
     let msg = to_message(&tx.to_vec());
     verify_signature(gpk, &msg, sig)
@@ -138,6 +184,17 @@ impl EpisodeEventHandler<ReceiptEpisode> for MerchantEventHandler {
         emit_checkpoint(episode_id, episode, force);
         if matches!(cmd, MerchantCommand::CancelInvoice { .. }) {
             forward_dispute(episode_id, episode);
+        }
+        if let Some(id) = match cmd {
+            MerchantCommand::CreateInvoice { invoice_id, .. } => Some(*invoice_id),
+            MerchantCommand::MarkPaid { invoice_id, .. } => Some(*invoice_id),
+            MerchantCommand::AckReceipt { invoice_id } => Some(*invoice_id),
+            MerchantCommand::CancelInvoice { invoice_id } => Some(*invoice_id),
+            _ => None,
+        } {
+            if let Some(inv) = episode.invoices.get(&id) {
+                notify_invoice(inv);
+            }
         }
     }
 

--- a/examples/tests/guardian_refund.rs
+++ b/examples/tests/guardian_refund.rs
@@ -43,6 +43,7 @@ fn scenario_a_refund_signed_and_recorded() {
         mainnet: false,
         key_path: key_path.clone(),
         log_level: "info".into(),
+        http_port: None,
     };
     let handle = run(&cfg);
     let state = handle.state.clone();
@@ -89,7 +90,14 @@ fn scenario_b_replay_confirm_rejected() {
     drop(tmp);
     let listen = format!("127.0.0.1:{port}");
 
-    let cfg = GuardianConfig { listen_addr: listen.clone(), wrpc_url: None, mainnet: false, key_path, log_level: "info".into() };
+    let cfg = GuardianConfig {
+        listen_addr: listen.clone(),
+        wrpc_url: None,
+        mainnet: false,
+        key_path,
+        log_level: "info".into(),
+        http_port: None,
+    };
     let handle = run(&cfg);
     let state = handle.state.clone();
 


### PR DESCRIPTION
## Summary
- guardian service exposes `/metrics` JSON and accepts `--http-port`
- watcher serves `/mempool` with base fee and policy details
- merchant sends webhook callbacks on invoice state changes

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_68c13e7b0230832b934756295b713deb