### PR TITLE
feat: expose metrics and invoice webhooks

### DIFF
--- a/examples/kdapp-merchant/README.md
+++ b/examples/kdapp-merchant/README.md
@@ -76,8 +76,11 @@ If you start the watcher with `--http-port <port>`, it exposes:
 GET /mempool
 
 {
-  "base_fee": 5000,
-  "congestion": 0.42
+  "est_base_fee": 5000,
+  "congestion_ratio": 0.42,
+  "min": 1000,
+  "max": 10000,
+  "policy": "default"
 }
 ```
 


### PR DESCRIPTION
## Summary
- guardian service exposes `/metrics` JSON and accepts `--http-port`
- watcher serves `/mempool` with base fee and policy details
- merchant sends signed webhook callbacks on invoice state changes with retries
- update watcher mempool metrics example in README

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_68c154942d2c832b96f9ace790e30b1c