### PR TITLE
feat(merchant): add NFC/BLE tap helpers

### DIFF
--- a/docs/nfc_ble.md
+++ b/docs/nfc_ble.md
@@ -1,0 +1,50 @@
+# NFC and BLE Invoice Encoding
+
+This document describes the minimal data formats used when exchanging
+invoice requests via NFC tags or BLE characteristics.
+
+## NFC
+
+Invoice requests are encoded as a single NDEF URI record using the
+`onlykas` scheme:
+
+```
+onlykas://invoice/{invoice_id}?amount={amount}&memo={memo}
+```
+
+Example:
+
+```
+onlykas://invoice/42?amount=2500&memo=coffee
+```
+
+A wallet or web application reads the URI from the NDEF record and
+parses the invoice id, amount and optional memo. The helper functions in
+`examples/kdapp-merchant/src/tap.rs` provide `encode_ndef` and
+`decode_ndef` utilities.
+
+## BLE
+
+BLE devices expose a characteristic containing a TLV encoded
+`CreateInvoice` request. The bytes follow the `TlvMsg` structure defined
+in `examples/kdapp-merchant/src/tlv.rs` with `msg_type = Cmd`. The TLV
+payload is the Borsh serialization of the
+`MerchantCommand::CreateInvoice` variant.
+
+Applications can generate the characteristic bytes using
+`encode_ble` and parse them with `decode_ble`.
+
+Example usage in Rust:
+
+```rust
+use kdapp_merchant::tap::{InvoiceRequest, encode_ble, decode_ble};
+
+let req = InvoiceRequest { invoice_id: 7, amount: 10_000, memo: Some("latte".into()) };
+let bytes = encode_ble(&req); // send over BLE
+let parsed = decode_ble(&bytes).unwrap();
+assert_eq!(req, parsed);
+```
+
+These formats allow wallets to interact with merchant terminals without
+platform-specific code, preparing the path for future mobile
+implementations.

--- a/examples/kdapp-merchant/src/main.rs
+++ b/examples/kdapp-merchant/src/main.rs
@@ -6,6 +6,7 @@ mod scheduler;
 mod server;
 mod sim_router;
 mod storage;
+mod tap;
 mod tcp_router;
 mod tlv;
 mod udp_router;

--- a/examples/kdapp-merchant/src/tap.rs
+++ b/examples/kdapp-merchant/src/tap.rs
@@ -1,0 +1,106 @@
+use borsh::BorshDeserialize;
+
+use crate::episode::MerchantCommand;
+use crate::tlv::{MsgType, TlvMsg, TLV_VERSION};
+
+/// Basic invoice request used for NFC/BLE taps.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvoiceRequest {
+    pub invoice_id: u64,
+    pub amount: u64,
+    pub memo: Option<String>,
+}
+
+/// Encode the request as an NDEF URI record.
+/// Memo text is inserted verbatim; callers should percent-encode if necessary.
+pub fn encode_ndef(req: &InvoiceRequest) -> String {
+    let mut uri = format!("onlykas://invoice/{}?amount={}", req.invoice_id, req.amount);
+    if let Some(m) = &req.memo {
+        uri.push_str("&memo=");
+        uri.push_str(m);
+    }
+    uri
+}
+
+/// Decode the request from an NDEF URI record.
+pub fn decode_ndef(uri: &str) -> Option<InvoiceRequest> {
+    const PREFIX: &str = "onlykas://invoice/";
+    if !uri.starts_with(PREFIX) {
+        return None;
+    }
+    let rest = &uri[PREFIX.len()..];
+    let mut parts = rest.split('?');
+    let id_part = parts.next()?;
+    let invoice_id: u64 = id_part.parse().ok()?;
+    let mut amount = None;
+    let mut memo = None;
+    if let Some(q) = parts.next() {
+        for pair in q.split('&') {
+            if let Some((k, v)) = pair.split_once('=') {
+                match k {
+                    "amount" => amount = v.parse().ok(),
+                    "memo" => memo = Some(v.to_string()),
+                    _ => {}
+                }
+            }
+        }
+    }
+    Some(InvoiceRequest { invoice_id, amount: amount?, memo })
+}
+
+/// Encode the request into BLE characteristic bytes using TLV framing.
+pub fn encode_ble(req: &InvoiceRequest) -> Vec<u8> {
+    let cmd = MerchantCommand::CreateInvoice {
+        invoice_id: req.invoice_id,
+        amount: req.amount,
+        memo: req.memo.clone(),
+        guardian_keys: Vec::new(),
+    };
+    let payload = borsh::to_vec(&cmd).expect("serialize command");
+    let tlv = TlvMsg {
+        version: TLV_VERSION,
+        msg_type: MsgType::Cmd as u8,
+        episode_id: 0,
+        seq: 0,
+        state_hash: [0u8; 32],
+        payload,
+        auth: [0u8; 32],
+    };
+    tlv.encode()
+}
+
+/// Decode the request from BLE characteristic bytes.
+pub fn decode_ble(bytes: &[u8]) -> Option<InvoiceRequest> {
+    let tlv = TlvMsg::decode(bytes)?;
+    if MsgType::from_u8(tlv.msg_type)? != MsgType::Cmd {
+        return None;
+    }
+    let cmd: MerchantCommand = MerchantCommand::try_from_slice(&tlv.payload).ok()?;
+    if let MerchantCommand::CreateInvoice { invoice_id, amount, memo, .. } = cmd {
+        Some(InvoiceRequest { invoice_id, amount, memo })
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ndef_round_trip() {
+        let req = InvoiceRequest { invoice_id: 42, amount: 25_000, memo: Some("coffee".into()) };
+        let uri = encode_ndef(&req);
+        let out = decode_ndef(&uri).expect("decode");
+        assert_eq!(req, out);
+    }
+
+    #[test]
+    fn ble_round_trip() {
+        let req = InvoiceRequest { invoice_id: 7, amount: 10_000, memo: Some("latte".into()) };
+        let bytes = encode_ble(&req);
+        let out = decode_ble(&bytes).expect("decode");
+        assert_eq!(req, out);
+    }
+}
+

--- a/examples/kdapp-merchant/src/tlv.rs
+++ b/examples/kdapp-merchant/src/tlv.rs
@@ -6,7 +6,7 @@ pub const DEMO_HMAC_KEY: &[u8] = b"kdapp-demo-secret";
 
 pub const TLV_VERSION: u8 = 1;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum MsgType {
     New = 0,


### PR DESCRIPTION
## Summary
- document NFC URI and BLE TLV formats for invoice requests
- add `tap` module with encode/decode helpers and round-trip tests
- expose `tap` module in merchant example
- fix serialization helpers and TLV comparison for clippy
- clarify memo encoding in NDEF helper

## Testing
- ⚠️ `cargo clippy --workspace --all-targets -- -D warnings` *(not run: repository policy to avoid cargo invocations)*
- ⚠️ `cargo test --workspace` *(not run: repository policy to avoid cargo invocations)*

------
https://chatgpt.com/codex/tasks/task_e_68c15cfc8d98832b8ff96a36b86773d3