### PR TITLE
feat(guardian): add config and key management

### DIFF
--- a/examples/kdapp-guardian/Cargo.toml
+++ b/examples/kdapp-guardian/Cargo.toml
@@ -17,10 +17,14 @@ secp256k1 = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 serde = { workspace = true, features = ["derive"] }
 toml = "0.8"
-faster-hex = { workspace = true }
 env_logger = { workspace = true }
 serde_json = "1.0"
 axum = { version = "0.8", features = ["http1", "json", "tokio"] }
+rand = { workspace = true }
+sha2 = { workspace = true }
+ripemd = "0.1"
+hex = "0.4"
+anyhow = "1.0"
 
 [[bin]]
 name = "guardian-service"

--- a/examples/kdapp-guardian/src/main.rs
+++ b/examples/kdapp-guardian/src/main.rs
@@ -1,9 +1,19 @@
-use env_logger::Env;
-use kdapp_guardian::service::{run, GuardianConfig};
+use std::fs;
 
-fn main() {
-    let config = GuardianConfig::from_args();
-    env_logger::Builder::from_env(Env::default().default_filter_or(&config.log_level)).init();
-    let _handle = run(&config);
+use clap::Parser;
+use env_logger::Env;
+use kdapp_guardian::service::{run, Cli, GuardianConfig};
+
+fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    let mut cfg = GuardianConfig::default();
+    if let Some(cfg_path) = &cli.config {
+        let s = fs::read_to_string(cfg_path)?;
+        cfg = toml::from_str(&s)?;
+    }
+    cfg = cli.merge_into_config(cfg);
+    env_logger::Builder::from_env(Env::default().default_filter_or(&cfg.log_level)).init();
+    let _handle = run(cfg);
     std::thread::park();
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- add configurable GuardianConfig with CLI/TOML parsing
- generate or load secp256k1 key and log fingerprint
- bind UDP socket and pass wRPC settings

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_68c29d1ca37c832b8a668c93321c5e6b