### PR TITLE
feat: add invoice webhook notifications

### DIFF
--- a/examples/kdapp-merchant/Cargo.toml
+++ b/examples/kdapp-merchant/Cargo.toml
@@ -28,6 +28,7 @@ axum = { version = "0.8", features = ["http1", "json", "tokio"] }
 kdapp-guardian = { path = "../kdapp-guardian" }
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 rand = { workspace = true }
+hmac = "0.12"
 
 [dev-dependencies]
 

--- a/examples/kdapp-merchant/src/handler.rs
+++ b/examples/kdapp-merchant/src/handler.rs
@@ -1,16 +1,12 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::{Mutex, OnceLock};
-use std::thread;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use faster_hex::hex_encode;
 use kdapp::episode::{EpisodeEventHandler, EpisodeId, PayloadMetadata};
 use kdapp::pki::{to_message, verify_signature, PubKey, Sig};
-use reqwest::blocking::Client;
-use serde::Serialize;
 
 use crate::client_sender;
-use crate::episode::{Invoice, MerchantCommand, ReceiptEpisode};
+use crate::episode::{MerchantCommand, ReceiptEpisode};
 use crate::storage;
 use crate::tlv::{hash_state, MsgType, TlvMsg, DEMO_HMAC_KEY, TLV_VERSION};
 use kdapp_guardian::{self as guardian};
@@ -25,7 +21,6 @@ static LAST_CKPT: OnceLock<Mutex<HashMap<EpisodeId, u64>>> = OnceLock::new();
 static DID_HANDSHAKE: OnceLock<()> = OnceLock::new();
 static GUARDIANS: OnceLock<Mutex<Vec<(String, PubKey)>>> = OnceLock::new();
 static GUARDIAN_HANDSHAKES: OnceLock<Mutex<HashSet<PubKey>>> = OnceLock::new();
-static WEBHOOK_URL: OnceLock<Option<String>> = OnceLock::new();
 
 fn now() -> u64 {
     SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs()
@@ -35,16 +30,6 @@ pub fn add_guardian(addr: String, pk: PubKey) {
     GUARDIANS.get_or_init(|| Mutex::new(Vec::new())).lock().unwrap().push((addr, pk));
 }
 
-pub fn set_webhook(url: Option<String>) {
-    WEBHOOK_URL.get_or_init(|| url);
-}
-
-fn pk_to_hex(pk: &PubKey) -> String {
-    let bytes = pk.0.serialize();
-    let mut out = vec![0u8; bytes.len() * 2];
-    hex_encode(&bytes, &mut out).expect("hex encode");
-    String::from_utf8(out).expect("utf8")
-}
 
 fn emit_checkpoint(episode_id: EpisodeId, episode: &ReceiptEpisode, force: bool) {
     // Ensure a handshake with the watcher before sending signed messages
@@ -122,35 +107,6 @@ fn forward_dispute(episode_id: EpisodeId, episode: &ReceiptEpisode) {
     }
 }
 
-#[derive(Serialize)]
-struct InvoiceEvent {
-    id: u64,
-    amount: u64,
-    memo: Option<String>,
-    status: String,
-    payer: Option<String>,
-    created_at: u64,
-    last_update: u64,
-}
-
-fn notify_invoice(inv: &Invoice) {
-    let url = match WEBHOOK_URL.get().and_then(|u| u.clone()) {
-        Some(u) => u,
-        None => return,
-    };
-    let event = InvoiceEvent {
-        id: inv.id,
-        amount: inv.amount,
-        memo: inv.memo.clone(),
-        status: format!("{:?}", inv.status),
-        payer: inv.payer.as_ref().map(pk_to_hex),
-        created_at: inv.created_at,
-        last_update: inv.last_update,
-    };
-    thread::spawn(move || {
-        let _ = Client::new().post(&url).json(&event).send();
-    });
-}
 
 fn verify_guardian_cosign(tx: &[u8], sig: &Sig, gpk: &PubKey) -> bool {
     let msg = to_message(&tx.to_vec());
@@ -184,17 +140,6 @@ impl EpisodeEventHandler<ReceiptEpisode> for MerchantEventHandler {
         emit_checkpoint(episode_id, episode, force);
         if matches!(cmd, MerchantCommand::CancelInvoice { .. }) {
             forward_dispute(episode_id, episode);
-        }
-        if let Some(id) = match cmd {
-            MerchantCommand::CreateInvoice { invoice_id, .. } => Some(*invoice_id),
-            MerchantCommand::MarkPaid { invoice_id, .. } => Some(*invoice_id),
-            MerchantCommand::AckReceipt { invoice_id } => Some(*invoice_id),
-            MerchantCommand::CancelInvoice { invoice_id } => Some(*invoice_id),
-            _ => None,
-        } {
-            if let Some(inv) = episode.invoices.get(&id) {
-                notify_invoice(inv);
-            }
         }
     }
 

--- a/examples/kdapp-merchant/src/server.rs
+++ b/examples/kdapp-merchant/src/server.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::Mutex;
+use tokio::time::sleep;
 
 use axum::{
     extract::{Json, State},
@@ -11,6 +13,8 @@ use kdapp::engine::EpisodeMessage;
 use kdapp::pki::PubKey;
 use secp256k1::SecretKey;
 use serde::{Deserialize, Serialize};
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
 
 use crate::episode::{MerchantCommand, ReceiptEpisode};
 use crate::sim_router::SimRouter;
@@ -31,6 +35,8 @@ pub struct AppState {
     merchant_pk: PubKey,
     api_key: String,
     watcher_overrides: Arc<Mutex<WatcherRuntimeOverrides>>,
+    webhook_url: Option<String>,
+    webhook_secret: Option<Vec<u8>>,
 }
 
 impl AppState {
@@ -42,6 +48,8 @@ impl AppState {
         api_key: String,
         max_fee: Option<u64>,
         congestion_threshold: Option<f64>,
+        webhook_url: Option<String>,
+        webhook_secret: Option<Vec<u8>>,
     ) -> Self {
         let overrides = watcher::WATCHER_OVERRIDES.clone();
         {
@@ -49,14 +57,83 @@ impl AppState {
             o.max_fee = max_fee;
             o.congestion_threshold = congestion_threshold;
         }
-        Self { router, episode_id, merchant_sk, merchant_pk, api_key, watcher_overrides: overrides }
+        Self {
+            router,
+            episode_id,
+            merchant_sk,
+            merchant_pk,
+            api_key,
+            watcher_overrides: overrides,
+            webhook_url,
+            webhook_secret,
+        }
     }
+}
+
+#[derive(Serialize)]
+struct WebhookEvent {
+    event: String,
+    invoice_id: u64,
+    episode_id: u32,
+    amount: u64,
+    memo: Option<String>,
+    payer_pubkey: Option<String>,
+    timestamp: u64,
+}
+
+fn hmac_sha256(secret: &[u8], message: &str) -> [u8; 32] {
+    let mut mac = Hmac::<Sha256>::new_from_slice(secret).expect("hmac init");
+    mac.update(message.as_bytes());
+    mac.finalize().into_bytes().into()
+}
+
+fn spawn_webhook(state: &AppState, event: WebhookEvent) {
+    let (url, secret) = match (state.webhook_url.clone(), state.webhook_secret.clone()) {
+        (Some(u), Some(s)) => (u, s),
+        _ => return,
+    };
+    tokio::spawn(async move {
+        let body = match serde_json::to_string(&event) {
+            Ok(b) => b,
+            Err(e) => {
+                log::warn!("webhook serialize failed: {e}");
+                return;
+            }
+        };
+        let sig = hmac_sha256(&secret, &body);
+        let sig_hex = {
+            let mut out = vec![0u8; sig.len() * 2];
+            faster_hex::hex_encode(&sig, &mut out).expect("hex encode");
+            String::from_utf8(out).expect("utf8")
+        };
+        let client = reqwest::Client::new();
+        let mut delay = 1u64;
+        for attempt in 0..3 {
+            let res = client
+                .post(&url)
+                .header("X-Signature", sig_hex.clone())
+                .body(body.clone())
+                .send()
+                .await;
+            match res {
+                Ok(r) if r.status().is_success() => break,
+                Ok(r) => log::warn!("webhook POST failed: status {}", r.status()),
+                Err(e) => log::warn!("webhook POST failed: {e}"),
+            }
+            if attempt < 2 {
+                sleep(Duration::from_secs(delay)).await;
+                delay *= 3;
+            }
+        }
+    });
 }
 
 pub async fn serve(bind: String, state: AppState) -> Result<(), Box<dyn std::error::Error>> {
     let app = Router::new()
         .route("/invoice", post(create_invoice))
         .route("/pay", post(pay_invoice))
+        .route("/ack", post(ack_invoice))
+        .route("/cancel", post(cancel_invoice))
         .route("/subscribe", post(create_subscription))
         .route("/invoices", get(list_invoices))
         .route("/subscriptions", get(list_subscriptions))
@@ -91,12 +168,35 @@ async fn create_invoice(
     Json(req): Json<CreateInvoiceReq>,
 ) -> Result<StatusCode, StatusCode> {
     authorize(&headers, &state)?;
-    let gkeys = req.guardian_public_keys.unwrap_or_default().iter().filter_map(|h| parse_public_key(h)).collect();
-    let cmd = MerchantCommand::CreateInvoice { invoice_id: req.invoice_id, amount: req.amount, memo: req.memo, guardian_keys: gkeys };
+    let gkeys = req
+        .guardian_public_keys
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|h| parse_public_key(h))
+        .collect();
+    let cmd = MerchantCommand::CreateInvoice {
+        invoice_id: req.invoice_id,
+        amount: req.amount,
+        memo: req.memo.clone(),
+        guardian_keys: gkeys,
+    };
     let msg = EpisodeMessage::new_signed_command(state.episode_id, cmd, state.merchant_sk, state.merchant_pk);
     if let Err(e) = state.router.forward::<ReceiptEpisode>(msg) {
         log::warn!("forward failed: {e}");
     }
+    let event = WebhookEvent {
+        event: "invoice_created".into(),
+        invoice_id: req.invoice_id,
+        episode_id: state.episode_id,
+        amount: req.amount,
+        memo: req.memo,
+        payer_pubkey: None,
+        timestamp: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs(),
+    };
+    spawn_webhook(&state, event);
     Ok(StatusCode::ACCEPTED)
 }
 
@@ -118,6 +218,95 @@ async fn pay_invoice(
     if let Err(e) = state.router.forward::<ReceiptEpisode>(msg) {
         log::warn!("forward failed: {e}");
     }
+    let (amount, memo) = storage::load_invoices()
+        .get(&req.invoice_id)
+        .map(|inv| (inv.amount, inv.memo.clone()))
+        .unwrap_or((0, None));
+    let event = WebhookEvent {
+        event: "invoice_paid".into(),
+        invoice_id: req.invoice_id,
+        episode_id: state.episode_id,
+        amount,
+        memo,
+        payer_pubkey: Some(req.payer_public_key),
+        timestamp: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs(),
+    };
+    spawn_webhook(&state, event);
+    Ok(StatusCode::ACCEPTED)
+}
+
+#[derive(Deserialize)]
+struct AckInvoiceReq {
+    invoice_id: u64,
+}
+
+async fn ack_invoice(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(req): Json<AckInvoiceReq>,
+) -> Result<StatusCode, StatusCode> {
+    authorize(&headers, &state)?;
+    let cmd = MerchantCommand::AckReceipt { invoice_id: req.invoice_id };
+    let msg = EpisodeMessage::new_signed_command(state.episode_id, cmd, state.merchant_sk, state.merchant_pk);
+    if let Err(e) = state.router.forward::<ReceiptEpisode>(msg) {
+        log::warn!("forward failed: {e}");
+    }
+    let (amount, memo, payer) = storage::load_invoices()
+        .get(&req.invoice_id)
+        .map(|inv| (inv.amount, inv.memo.clone(), inv.payer.as_ref().map(pk_to_hex)))
+        .unwrap_or((0, None, None));
+    let event = WebhookEvent {
+        event: "invoice_acked".into(),
+        invoice_id: req.invoice_id,
+        episode_id: state.episode_id,
+        amount,
+        memo,
+        payer_pubkey: payer,
+        timestamp: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs(),
+    };
+    spawn_webhook(&state, event);
+    Ok(StatusCode::ACCEPTED)
+}
+
+#[derive(Deserialize)]
+struct CancelInvoiceReq {
+    invoice_id: u64,
+}
+
+async fn cancel_invoice(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(req): Json<CancelInvoiceReq>,
+) -> Result<StatusCode, StatusCode> {
+    authorize(&headers, &state)?;
+    let cmd = MerchantCommand::CancelInvoice { invoice_id: req.invoice_id };
+    let msg = EpisodeMessage::<ReceiptEpisode>::UnsignedCommand { episode_id: state.episode_id, cmd };
+    if let Err(e) = state.router.forward::<ReceiptEpisode>(msg) {
+        log::warn!("forward failed: {e}");
+    }
+    let (amount, memo, payer) = storage::load_invoices()
+        .get(&req.invoice_id)
+        .map(|inv| (inv.amount, inv.memo.clone(), inv.payer.as_ref().map(pk_to_hex)))
+        .unwrap_or((0, None, None));
+    let event = WebhookEvent {
+        event: "invoice_cancelled".into(),
+        invoice_id: req.invoice_id,
+        episode_id: state.episode_id,
+        amount,
+        memo,
+        payer_pubkey: payer,
+        timestamp: SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs(),
+    };
+    spawn_webhook(&state, event);
     Ok(StatusCode::ACCEPTED)
 }
 


### PR DESCRIPTION
## Summary
- add `--webhook-url` and `--webhook-secret` to merchant server
- post signed JSON webhooks on invoice state transitions
- expose HTTP endpoints for acknowledging and cancelling invoices

## Testing
- ⚠️ `cargo test --workspace` *(skipped: cargo commands disallowed in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c2acef8f68832b89e9848859ce1da7