### PR TITLE
feat: add subscription dispute scaffolding

### DIFF
--- a/examples/kdapp-merchant/src/scheduler.rs
+++ b/examples/kdapp-merchant/src/scheduler.rs
@@ -24,14 +24,14 @@ pub fn start(router: SimRouter, episode_id: u32) {
             let current = now();
             let subs = storage::load_subscriptions();
             for (id, mut sub) in subs {
-                if sub.next_run <= current {
+                if sub.next_run_ts <= current {
                     let cmd = MerchantCommand::ProcessSubscription { subscription_id: id };
                     let msg = EpisodeMessage::UnsignedCommand { episode_id, cmd };
                     if let Err(e) = router.forward::<ReceiptEpisode>(msg) {
                         let delay = backoffs.get(&id).copied().unwrap_or(INITIAL_BACKOFF);
                         let next_delay = (delay * 2).min(MAX_BACKOFF);
                         backoffs.insert(id, next_delay);
-                        sub.next_run = current + delay;
+                        sub.next_run_ts = current + delay;
                         storage::put_subscription(&sub);
                         warn!("forward failed for subscription {id}, retrying in {delay}s: {e}");
                     } else {

--- a/examples/kdapp-merchant/src/tlv.rs
+++ b/examples/kdapp-merchant/src/tlv.rs
@@ -1,4 +1,5 @@
 use blake2::{Blake2b512, Digest};
+use serde::{Deserialize, Serialize};
 
 /// Demo shared secret used for HMAC signing of TLV messages.
 /// In real deployments this should be negotiated out of band.
@@ -17,6 +18,10 @@ pub enum MsgType {
     Checkpoint = 5,
     Handshake = 6,
     Refund = 7,
+    SubCharge = 8,
+    SubChargeAck = 9,
+    SubDispute = 10,
+    SubDisputeResolve = 11,
 }
 
 impl MsgType {
@@ -30,9 +35,33 @@ impl MsgType {
             5 => Some(MsgType::Checkpoint),
             6 => Some(MsgType::Handshake),
             7 => Some(MsgType::Refund),
+            8 => Some(MsgType::SubCharge),
+            9 => Some(MsgType::SubChargeAck),
+            10 => Some(MsgType::SubDispute),
+            11 => Some(MsgType::SubDisputeResolve),
             _ => None,
         }
     }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SubChargeMsg {
+    pub sub_id: u64,
+    pub period_start_ts: u64,
+    pub period_end_ts: u64,
+    pub expected_amount: u64,
+    pub invoice_id: u64,
+    pub merchant_pubkey: Vec<u8>,
+    pub hmac: Vec<u8>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SubDisputeMsg {
+    pub sub_id: u64,
+    pub invoice_id: u64,
+    pub reason: String,
+    pub evidence_hash: Vec<u8>,
+    pub proposed_refund_tx: Option<Vec<u8>>,
 }
 
 #[derive(Clone)]

--- a/examples/kdapp-merchant/tests/subscriptions.rs
+++ b/examples/kdapp-merchant/tests/subscriptions.rs
@@ -14,7 +14,7 @@ fn subscription_creation_and_recurring_charges() {
     create_subscription(&mut ctx, 1, 100, interval);
     let expected = ctx.metadata.accepting_time + interval;
     let jitter = std::cmp::max(1, interval * 5 / 100);
-    let first_run = ctx.episode.subscriptions.get(&1).unwrap().next_run;
+    let first_run = ctx.episode.subscriptions.get(&1).unwrap().next_run_ts;
     assert!(first_run >= expected - jitter && first_run <= expected + jitter);
 
     // process twice to simulate recurring charges
@@ -22,13 +22,13 @@ fn subscription_creation_and_recurring_charges() {
     md.accepting_time = first_run;
     ctx.episode.execute(&MerchantCommand::ProcessSubscription { subscription_id: 1 }, None, &md).expect("process once");
     let second_expected = first_run + interval;
-    let second_run = ctx.episode.subscriptions.get(&1).unwrap().next_run;
+    let second_run = ctx.episode.subscriptions.get(&1).unwrap().next_run_ts;
     assert!(second_run >= second_expected - jitter && second_run <= second_expected + jitter);
 
     md.accepting_time = second_run;
     ctx.episode.execute(&MerchantCommand::ProcessSubscription { subscription_id: 1 }, None, &md).expect("process twice");
     let third_expected = second_run + interval;
-    let third_run = ctx.episode.subscriptions.get(&1).unwrap().next_run;
+    let third_run = ctx.episode.subscriptions.get(&1).unwrap().next_run_ts;
     assert!(third_run >= third_expected - jitter && third_run <= third_expected + jitter);
 }
 


### PR DESCRIPTION
## Summary
- extend TLV and episodes with subscription charge and dispute structures
- add stubbed charge/dispute handlers and HTTP routes for subscriptions
- track subscription disputes in guardian state

## Testing
- ⚠️ `cargo fmt --all` *(skipped: repo instructions prohibit running cargo commands)*
- ⚠️ `cargo clippy --workspace --all-targets -- -D warnings` *(skipped: repo instructions prohibit running cargo commands)*
- ⚠️ `cargo test --workspace` *(skipped: repo instructions prohibit running cargo commands)*

------
https://chatgpt.com/codex/tasks/task_e_68c3c1a41cb4832bb792cad202b8ef76