### PR TITLE
feat(subscription): add validation and dispute scaffolding

### DIFF
--- a/examples/kdapp-customer/src/tlv.rs
+++ b/examples/kdapp-customer/src/tlv.rs
@@ -14,6 +14,10 @@ pub enum MsgType {
     AckClose = 4,
     Checkpoint = 5,
     Handshake = 6,
+    SubCharge = 7,
+    SubChargeAck = 8,
+    SubDispute = 9,
+    SubDisputeResolve = 10,
 }
 
 impl MsgType {
@@ -26,6 +30,10 @@ impl MsgType {
             4 => Some(MsgType::AckClose),
             5 => Some(MsgType::Checkpoint),
             6 => Some(MsgType::Handshake),
+            7 => Some(MsgType::SubCharge),
+            8 => Some(MsgType::SubChargeAck),
+            9 => Some(MsgType::SubDispute),
+            10 => Some(MsgType::SubDisputeResolve),
             _ => None,
         }
     }

--- a/examples/kdapp-merchant/src/storage.rs
+++ b/examples/kdapp-merchant/src/storage.rs
@@ -119,7 +119,7 @@ pub fn load_subscriptions() -> BTreeMap<u64, Subscription> {
 
 pub fn put_subscription(sub: &Subscription) {
     let tree = DB.open_tree("subscriptions").expect("subscriptions tree");
-    let key = sub.id.to_be_bytes();
+    let key = sub.sub_id.to_be_bytes();
     let val = borsh::to_vec(sub).expect("serialize subscription");
     let _ = tree.insert(key, val);
 }

--- a/examples/kdapp-merchant/src/tlv.rs
+++ b/examples/kdapp-merchant/src/tlv.rs
@@ -45,7 +45,7 @@ impl MsgType {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct SubChargeMsg {
+pub struct SubCharge {
     pub sub_id: u64,
     pub period_start_ts: u64,
     pub period_end_ts: u64,
@@ -56,12 +56,27 @@ pub struct SubChargeMsg {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct SubDisputeMsg {
+pub struct SubChargeAck {
+    pub sub_id: u64,
+    pub ok: bool,
+    pub reason: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SubDispute {
     pub sub_id: u64,
     pub invoice_id: u64,
     pub reason: String,
     pub evidence_hash: Vec<u8>,
     pub proposed_refund_tx: Option<Vec<u8>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SubDisputeResolve {
+    pub sub_id: u64,
+    pub invoice_id: u64,
+    pub guardian_sig: Vec<u8>,
+    pub refund_tx: Option<Vec<u8>>,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
## Summary
- define shared `Subscription` and status types
- add TLV messages for subscription charging and dispute resolution
- expose handlers for customer charges and guardian disputes

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_68c3fc8f5304832b97e37e651deaf200