### PR TITLE
feat(onlykas-tui): add invoice actions and status toasts

### DIFF
--- a/examples/onlykas-tui/src/actions.rs
+++ b/examples/onlykas-tui/src/actions.rs
@@ -7,6 +7,9 @@ pub enum Action {
     FocusPrev,
     SelectNext,
     SelectPrev,
+    NewInvoice,
+    SimulatePay,
+    Acknowledge,
     None,
 }
 
@@ -15,6 +18,9 @@ impl Action {
         match key.code {
             KeyCode::Char('q') => Action::Quit,
             KeyCode::Char('r') => Action::Refresh,
+            KeyCode::Char('n') => Action::NewInvoice,
+            KeyCode::Char('p') => Action::SimulatePay,
+            KeyCode::Char('a') => Action::Acknowledge,
             KeyCode::Left => Action::FocusPrev,
             KeyCode::Right => Action::FocusNext,
             KeyCode::Up => Action::SelectPrev,

--- a/examples/onlykas-tui/src/ui.rs
+++ b/examples/onlykas-tui/src/ui.rs
@@ -27,7 +27,12 @@ pub fn draw<B: Backend>(f: &mut Frame<B>, app: &App) {
     render_guardian(f, app, chunks[4]);
     render_webhooks(f, app, chunks[5]);
 
-    let status = Paragraph::new(format!("focus: {:?}", app.focus));
+    let (text, color) = if let Some(status) = &app.status {
+        (status.msg.clone(), status.color)
+    } else {
+        (format!("focus: {:?}", app.focus), Color::White)
+    };
+    let status = Paragraph::new(text).style(Style::default().fg(color));
     f.render_widget(status, chunks[6]);
 }
 
@@ -44,6 +49,9 @@ fn render_actions<B: Backend>(f: &mut Frame<B>, app: &App, area: Rect) {
     let items = vec![
         Line::raw("q: quit"),
         Line::raw("r: refresh"),
+        Line::raw("n: new invoice"),
+        Line::raw("p: simulate pay"),
+        Line::raw("a: acknowledge"),
         Line::raw("arrows: navigate"),
     ];
     f.render_widget(Paragraph::new(items).block(block), area);


### PR DESCRIPTION
## Summary
- add keyboard shortcuts for creating, paying, and acknowledging invoices
- show transient status messages in TUI
- support mocked L1 payment simulation and acknowledgements

## Testing
- ⚠️ `cargo fmt --all`
- ⚠️ `cargo clippy --workspace --all-targets -- -D warnings`
- ⚠️ `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_68c559e8ef54832b98433b318ee1acf9