### PR TITLE
feat(tui): add watcher config modal

### DIFF
--- a/examples/onlykas-tui/src/actions.rs
+++ b/examples/onlykas-tui/src/actions.rs
@@ -10,6 +10,7 @@ pub enum Action {
     NewInvoice,
     SimulatePay,
     Acknowledge,
+    WatcherConfig,
     None,
 }
 
@@ -21,6 +22,7 @@ impl Action {
             KeyCode::Char('n') => Action::NewInvoice,
             KeyCode::Char('p') => Action::SimulatePay,
             KeyCode::Char('a') => Action::Acknowledge,
+            KeyCode::Char('w') => Action::WatcherConfig,
             KeyCode::Left => Action::FocusPrev,
             KeyCode::Right => Action::FocusNext,
             KeyCode::Up => Action::SelectPrev,


### PR DESCRIPTION
## Summary
- add watcher config modal to onlykas TUI
- allow editing fee mode and thresholds with validation
- wire POST /watcher-config and status notifications
- clarify imports for the TUI's UI module

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68c55bd94948832b9cc005be9fefffd1