### PR TITLE
feat(tui): add dispute support to invoices

### DIFF
--- a/examples/onlykas-tui/src/actions.rs
+++ b/examples/onlykas-tui/src/actions.rs
@@ -10,6 +10,7 @@ pub enum Action {
     NewInvoice,
     SimulatePay,
     Acknowledge,
+    Dispute,
     WatcherConfig,
     None,
 }
@@ -22,6 +23,7 @@ impl Action {
             KeyCode::Char('n') => Action::NewInvoice,
             KeyCode::Char('p') => Action::SimulatePay,
             KeyCode::Char('a') => Action::Acknowledge,
+            KeyCode::Char('d') => Action::Dispute,
             KeyCode::Char('w') => Action::WatcherConfig,
             KeyCode::Left => Action::FocusPrev,
             KeyCode::Right => Action::FocusNext,

--- a/examples/onlykas-tui/src/main.rs
+++ b/examples/onlykas-tui/src/main.rs
@@ -194,6 +194,9 @@ async fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: Arc<Mutex<App>>) -
                         Action::Acknowledge => {
                             app.acknowledge_invoice().await;
                         }
+                        Action::Dispute => {
+                            app.dispute_invoice().await;
+                        }
                         Action::WatcherConfig => {
                             app.open_watcher_config();
                         }

--- a/examples/onlykas-tui/src/ui.rs
+++ b/examples/onlykas-tui/src/ui.rs
@@ -61,6 +61,7 @@ fn render_actions<B: Backend>(f: &mut Frame<B>, app: &App, area: Rect) {
         Line::raw("n: new invoice"),
         Line::raw("p: simulate pay"),
         Line::raw("a: acknowledge"),
+        Line::raw("d: dispute"),
         Line::raw("w: watcher config"),
         Line::raw("arrows: navigate"),
     ];
@@ -83,7 +84,20 @@ fn render_watcher<B: Backend>(f: &mut Frame<B>, app: &App, area: Rect) {
 
 fn render_guardian<B: Backend>(f: &mut Frame<B>, app: &App, area: Rect) {
     let block = panel_block("Guardian", app.focus == Focus::Guardian);
-    f.render_widget(Paragraph::new(format!("{}", app.guardian)).block(block), area);
+    let text = if let Some(obj) = app.guardian.as_object() {
+        let disputes = obj
+            .get("disputes_open")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
+        let refunds = obj
+            .get("refunds_signed")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
+        format!("disputes_open: {}\nrefunds_signed: {}", disputes, refunds)
+    } else {
+        format!("{}", app.guardian)
+    };
+    f.render_widget(Paragraph::new(text).block(block), area);
 }
 
 fn render_webhooks<B: Backend>(f: &mut Frame<B>, app: &App, area: Rect) {


### PR DESCRIPTION
## Summary
- add dispute action to onlykas TUI
- show guardian dispute and refund metrics
- attempt guardian dispute API first then merchant

## Testing
- ⚠️ `cargo fmt --all` *(skipped: repository instructions prohibit running cargo commands)*
- ⚠️ `cargo clippy --workspace --all-targets -- -D warnings` *(skipped: repository instructions prohibit running cargo commands)*
- ⚠️ `cargo test --workspace` *(skipped: repository instructions prohibit running cargo commands)*

------
https://chatgpt.com/codex/tasks/task_e_68c57b42db34832b96b1d45345ad9fab