### PR TITLE
feat(onlykas-tui): add subscription management

### DIFF
--- a/examples/onlykas-tui/src/actions.rs
+++ b/examples/onlykas-tui/src/actions.rs
@@ -12,6 +12,8 @@ pub enum Action {
     Acknowledge,
     Dispute,
     WatcherConfig,
+    ChargeSub,
+    ToggleList,
     None,
 }
 
@@ -25,6 +27,8 @@ impl Action {
             KeyCode::Char('a') => Action::Acknowledge,
             KeyCode::Char('d') => Action::Dispute,
             KeyCode::Char('w') => Action::WatcherConfig,
+            KeyCode::Char('s') => Action::ChargeSub,
+            KeyCode::Tab => Action::ToggleList,
             KeyCode::Left => Action::FocusPrev,
             KeyCode::Right => Action::FocusNext,
             KeyCode::Up => Action::SelectPrev,

--- a/examples/onlykas-tui/src/main.rs
+++ b/examples/onlykas-tui/src/main.rs
@@ -178,6 +178,7 @@ async fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: Arc<Mutex<App>>) -
                         Action::FocusPrev => app.focus_prev(),
                         Action::SelectNext => app.select_next(),
                         Action::SelectPrev => app.select_prev(),
+                        Action::ToggleList => app.toggle_list_mode(),
                         Action::NewInvoice => {
                             if let Some(amount_s) = prompt("amount_sompi") {
                                 if let Ok(amount) = amount_s.parse::<u64>() {
@@ -199,6 +200,9 @@ async fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: Arc<Mutex<App>>) -
                         }
                         Action::WatcherConfig => {
                             app.open_watcher_config();
+                        }
+                        Action::ChargeSub => {
+                            app.charge_subscription().await;
                         }
                         Action::None => {}
                     }

--- a/examples/onlykas-tui/src/models.rs
+++ b/examples/onlykas-tui/src/models.rs
@@ -6,6 +6,17 @@ pub type Mempool = Value;
 pub type GuardianMetrics = Value;
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct Subscription {
+    pub id: u64,
+    #[serde(alias = "amount")]
+    pub amount_sompi: u64,
+    #[serde(alias = "period_secs")]
+    pub interval: u64,
+    #[serde(alias = "next_run_ts")]
+    pub next_charge_ts: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
 pub struct WebhookEvent {
     pub event: String,
     pub id: String,
@@ -20,4 +31,11 @@ pub fn invoice_to_string(inv: &Invoice) -> String {
         }
     }
     inv.to_string()
+}
+
+pub fn subscription_to_string(sub: &Subscription) -> String {
+    format!(
+        "{} amt {} int {} next {}",
+        sub.id, sub.amount_sompi, sub.interval, sub.next_charge_ts
+    )
 }


### PR DESCRIPTION
## Summary
- toggle between invoice and subscription lists in the TUI
- fetch subscriptions and allow manual charges via 's'
- show subscription webhook events alongside invoices

## Testing
- `N/A`

------
https://chatgpt.com/codex/tasks/task_e_68c57caa6c2c832b8e0794a694348970