### PR TITLE
feat(onlykas-tui): style logo paragraph

### DIFF
--- a/examples/onlykas-tui/src/logo.rs
+++ b/examples/onlykas-tui/src/logo.rs
@@ -1,9 +1,46 @@
-pub fn onlykas_logo() -> &'static str {
-    r#"
-  ___       _           _          
- / _ \ _ __(_)_   _____| | _____ _ 
-| | | | '__| \ \ / / _ \ |/ / _` |
-| |_| | |  | |\ V /  __/   < (_| |
- \___/|_|  |_| \_/ \___|_|\_\__,_|
-"#
+use ratatui::{prelude::*, widgets::Paragraph};
+
+pub fn onlykas_logo() -> Paragraph<'static> {
+    const ONLY: [&str; 5] = [
+        " ███  ███   █    █   █",
+        "█   █ █  █  █    █   █",
+        "█   █ █  █  █     ███",
+        "█   █ █  █  █        █",
+        " ███  █  █  ████  ███",
+    ];
+
+    const KAS: [&str; 5] = [
+        "█  ██  ███   ████",
+        "█ ██  █   █ █",
+        "███   █████  ███",
+        "█ ██  █   █     █",
+        "█  ██ █   █ ████",
+    ];
+
+    let left_width = ONLY.iter().map(|l| l.len()).max().unwrap_or(0);
+    let lines: Vec<Line> = ONLY
+        .iter()
+        .zip(KAS.iter())
+        .map(|(o, k)| {
+            let padded = format!("{:<width$}", o, width = left_width);
+            Line::from(vec![
+                Span::styled(
+                    padded,
+                    Style::default()
+                        .fg(Color::White)
+                        .bg(Color::Black)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    *k,
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .bg(Color::Black)
+                        .add_modifier(Modifier::BOLD),
+                ),
+            ])
+        })
+        .collect();
+
+    Paragraph::new(lines).alignment(Alignment::Center)
 }

--- a/examples/onlykas-tui/src/ui.rs
+++ b/examples/onlykas-tui/src/ui.rs
@@ -24,7 +24,7 @@ pub fn draw(f: &mut Frame, app: &App) {
         ])
         .split(size);
 
-    let header = Paragraph::new(logo::onlykas_logo()).alignment(Alignment::Center);
+    let header = logo::onlykas_logo();
     f.render_widget(header, chunks[0]);
 
     render_actions(f, app, chunks[1]);


### PR DESCRIPTION
## Summary
- replace ASCII logo with a colorized Paragraph using block glyph arrays for `only` and `KAS`
- render the new logo directly in `ui.rs`

## Testing
- `cargo run -p onlykas-tui` *(fails: failed to get `rocksdb` as a dependency of package `kdapp-indexer`)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c8fbbf70832b8b661edfaa4439d5