### PR TITLE
feat(onlykas-tui): simplify logo rendering

### DIFF
--- a/examples/onlykas-tui/src/logo.rs
+++ b/examples/onlykas-tui/src/logo.rs
@@ -1,46 +1,37 @@
 use ratatui::{prelude::*, widgets::Paragraph};
 
-pub fn onlykas_logo() -> Paragraph<'static> {
-    const ONLY: [&str; 5] = [
-        " ███  ███   █    █   █",
-        "█   █ █  █  █    █   █",
-        "█   █ █  █  █     ███",
-        "█   █ █  █  █        █",
-        " ███  █  █  ████  ███",
-    ];
+const LOGO: [&str; 5] = [
+    " ███  ███   █    █   ██  ██  ███   ████",
+    "█   █ █  █  █    █   ██ ██  █   █ █",
+    "█   █ █  █  █     ███ ███   █████  ███",
+    "█   █ █  █  █        ██ ██  █   █     █",
+    " ███  █  █  ████  ███ █  ██ █   █ ████",
+];
 
-    const KAS: [&str; 5] = [
-        "█  ██  ███   ████",
-        "█ ██  █   █ █",
-        "███   █████  ███",
-        "█ ██  █   █     █",
-        "█  ██ █   █ ████",
-    ];
+pub fn render_logo() -> Paragraph<'static> {
+    let k_index = LOGO[0].find("█  ██  ███").unwrap_or(0);
+    let white = Style::default()
+        .fg(Color::White)
+        .bg(Color::Black)
+        .add_modifier(Modifier::BOLD);
+    let teal = Style::default()
+        .fg(Color::Cyan)
+        .bg(Color::Black)
+        .add_modifier(Modifier::BOLD);
 
-    let left_width = ONLY.iter().map(|l| l.len()).max().unwrap_or(0);
-    let lines: Vec<Line> = ONLY
+    let lines: Vec<Line> = LOGO
         .iter()
-        .zip(KAS.iter())
-        .map(|(o, k)| {
-            let padded = format!("{:<width$}", o, width = left_width);
-            Line::from(vec![
-                Span::styled(
-                    padded,
-                    Style::default()
-                        .fg(Color::White)
-                        .bg(Color::Black)
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::styled(
-                    *k,
-                    Style::default()
-                        .fg(Color::Cyan)
-                        .bg(Color::Black)
-                        .add_modifier(Modifier::BOLD),
-                ),
-            ])
+        .map(|line| {
+            let (left, right) = line.split_at(k_index);
+            let spans = left
+                .chars()
+                .map(|c| Span::styled(c.to_string(), white))
+                .chain(right.chars().map(|c| Span::styled(c.to_string(), teal)))
+                .collect::<Vec<_>>();
+            Line::from(spans)
         })
         .collect();
 
     Paragraph::new(lines).alignment(Alignment::Center)
 }
+

--- a/examples/onlykas-tui/src/ui.rs
+++ b/examples/onlykas-tui/src/ui.rs
@@ -24,7 +24,7 @@ pub fn draw(f: &mut Frame, app: &App) {
         ])
         .split(size);
 
-    let header = logo::onlykas_logo();
+    let header = logo::render_logo();
     f.render_widget(header, chunks[0]);
 
     render_actions(f, app, chunks[1]);


### PR DESCRIPTION
## Summary
- replace separated logo fragments with single LOGO array
- render logo character-by-character with color split at K
- update UI to use new `render_logo`

## Testing
- `cargo run --example onlykas-tui` *(fails: Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_68c658046abc832b9d3e583b2a89518e