### PR TITLE
fix(onlykas-tui): ignore non-press key events

### DIFF
--- a/examples/onlykas-tui/src/actions.rs
+++ b/examples/onlykas-tui/src/actions.rs
@@ -1,4 +1,4 @@
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind};
 
 pub enum Action {
     Quit,
@@ -19,6 +19,9 @@ pub enum Action {
 
 impl Action {
     pub fn from_key(key: KeyEvent) -> Action {
+        if key.kind != KeyEventKind::Press {
+            return Action::None;
+        }
         match key.code {
             KeyCode::Char('q') => Action::Quit,
             KeyCode::Char('r') => Action::Refresh,


### PR DESCRIPTION
## Summary
- handle key events only on key press in onlykas-tui

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68c6a8a83974832bb0b2ec48e289cb07