### PR TITLE
fix(onlykas-tui): decouple selection from focus

### DIFF
--- a/examples/onlykas-tui/src/main.rs
+++ b/examples/onlykas-tui/src/main.rs
@@ -247,19 +247,11 @@ async fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: Arc<Mutex<App>>) -
                     }
                     Action::SelectNext => {
                         let mut a = app.lock().await;
-                        if a.focus == app::Focus::Invoices {
-                            a.select_next();
-                        } else {
-                            a.focus_next();
-                        }
+                        a.select_next();
                     }
                     Action::SelectPrev => {
                         let mut a = app.lock().await;
-                        if a.focus == app::Focus::Invoices {
-                            a.select_prev();
-                        } else {
-                            a.focus_prev();
-                        }
+                        a.select_prev();
                     }
                     Action::ToggleList => {
                         let mut a = app.lock().await;

--- a/examples/onlykas-tui/src/ui.rs
+++ b/examples/onlykas-tui/src/ui.rs
@@ -74,7 +74,8 @@ fn render_actions(f: &mut Frame, app: &App, area: Rect) {
         Line::raw("d: dispute"),
         Line::raw("s: charge sub"),
         Line::raw("w: watcher config"),
-        Line::raw("arrows: navigate"),
+        Line::raw("left/right: change focus"),
+        Line::raw("up/down: move selection"),
     ]);
     f.render_widget(Paragraph::new(items).block(block), area);
 }


### PR DESCRIPTION
## Summary
- Keep Up/Down arrow handling on list selection and prevent them from shifting focus
- Clarify navigation shortcuts in the Actions panel

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_68c6acf09180832b940764fb03cfbc5f