### PR TITLE
docs(onlykas-tui): clarify navigation keys

### DIFF
--- a/examples/onlykas-tui/README.md
+++ b/examples/onlykas-tui/README.md
@@ -102,14 +102,18 @@ Notes:
 ### Keys
 | Key | Action |
 | --- | --- |
+| `Left` / `Right` | Move focus between panels |
+| `Up` / `Down` | Scroll within the focused list |
+| `Tab` | Switch between invoice and subscription lists |
 | `n` | Create a new invoice |
 | `p` | Simulate payment (mock mode) |
 | `a` | Acknowledge the selected invoice |
 | `d` | Open a dispute for the selected invoice |
 | `w` | Configure watcher fee policy |
 | `r` | Refresh data from services |
-| `q` | Quit |
-Arrow keys navigate lists and `Tab` toggles between invoices and subscriptions.
+| `q` or `Ctrl+C` | Quit |
+
+Use `Left`/`Right` to change panels and `Up`/`Down` to navigate items within the active panel.
 
 ### Panels
 - **Actions** – shortcut reference.


### PR DESCRIPTION
## Summary
- document arrow keys for switching panels and scrolling lists in onlykas-tui README
- note Tab for switching invoice/subscription lists and Ctrl+C for quitting

## Testing
- No tests were run; please run `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_68c6b9408fe8832bab68eebfcfe90ded