### PR TITLE
fix(onlykas-tui): account for extra space in logo

### DIFF
--- a/examples/onlykas-tui/src/logo.rs
+++ b/examples/onlykas-tui/src/logo.rs
@@ -12,7 +12,7 @@ pub fn render_logo() -> Paragraph<'static> {
     // Find the split point using the first line, then convert to a character
     // column index so we can safely style per-char on all lines without
     // splitting at a potentially invalid UTF-8 byte boundary.
-    let k_byte_index = LOGO[0].find("█  ██  ███").unwrap_or(0);
+    let k_byte_index = LOGO[0].find("█   ██  ███").unwrap_or(0);
     let k_col = LOGO[0].char_indices().position(|(i, _)| i == k_byte_index).unwrap_or(0);
 
     let white = Style::default().fg(Color::White).bg(Color::Black).add_modifier(Modifier::BOLD);


### PR DESCRIPTION
## Summary
- adjust logo split detection to handle extra space

## Testing
- `cargo run -p onlykas-tui` *(fails: failed to download from crates.io: [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_68c6c10dbdd4832b9aa6b8c1b59916f1