### PR TITLE
fix(onlykas-tui): expose watcher and guardian metrics ports

### DIFF
--- a/examples/onlykas-tui/autopilot.ps1
+++ b/examples/onlykas-tui/autopilot.ps1
@@ -122,7 +122,8 @@ Start-Process -FilePath cargo -ArgumentList $watcherArgs -NoNewWindow -RedirectS
 
 # Start guardian
 $guardianArgs = @("run","-p","kdapp-guardian","--bin","guardian-service","--",
-  "--listen-addr","127.0.0.1:$GuardianPort"
+  "--listen-addr","127.0.0.1:$GuardianPort",
+  "--http-port",$GuardianPort
 )
 Start-Process -FilePath cargo -ArgumentList $guardianArgs -NoNewWindow -RedirectStandardOutput guardian.out -RedirectStandardError guardian.err
 
@@ -147,6 +148,7 @@ Write-Host "Starting onlykas-tui ..." -ForegroundColor Green
 $tuiArgs = @("run","-p","onlykas-tui","--",
   "--merchant-url","http://127.0.0.1:$MerchantPort",
   "--guardian-url","http://127.0.0.1:$GuardianPort",
+  "--watcher-url","http://127.0.0.1:$WatcherPort",
   "--webhook-secret","$WebhookSecret",
   "--api-key","$ApiKey",
   "--webhook-port","$WebhookPort"

--- a/examples/onlykas-tui/autopilot.sh
+++ b/examples/onlykas-tui/autopilot.sh
@@ -166,10 +166,12 @@ sleep 1
 if [[ "${DEBUG:-0}" == "1" ]]; then
   cargo run -p kdapp-guardian --bin guardian-service -- \
     --listen-addr 127.0.0.1:"$GUARDIAN_PORT" \
+    --http-port "$GUARDIAN_PORT" \
     2>&1 | tee -a "$LOG_PREFIX/guardian.log" &
 else
   cargo run -p kdapp-guardian --bin guardian-service -- \
     --listen-addr 127.0.0.1:"$GUARDIAN_PORT" \
+    --http-port "$GUARDIAN_PORT" \
     > "$LOG_PREFIX/guardian.out" 2> "$LOG_PREFIX/guardian.err" &
 fi
 sleep 1


### PR DESCRIPTION
## Summary
- include watcher URL when launching onlykas-tui from PowerShell autopilot
- start guardian-service with explicit metrics port and reuse it for the TUI
- mirror guardian metrics port usage in the Bash autopilot

## Testing
- `shellcheck examples/onlykas-tui/autopilot.sh` *(fails: command not found)*
- `pwsh -NoProfile -Command "Import-Module PSScriptAnalyzer; Invoke-ScriptAnalyzer -EnableExit -Path 'examples/onlykas-tui/autopilot.ps1'"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7c9cf87a0832b9a2753d4bb9ca671