### PR TITLE
fix(onlykas-tui): handle missing subscription selection

### DIFF
--- a/examples/onlykas-tui/autopilot.sh
+++ b/examples/onlykas-tui/autopilot.sh
@@ -187,6 +187,19 @@ if [[ "${DEBUG:-0}" == "1" ]]; then
   cargo run -p kdapp-merchant -- kaspa-addr --kaspa-private-key "$KASPA_SK" ${NET_ARGS[@]:-}
 fi
 
+# Seed a demo subscription for testing
+CUSTOMER_SK=$(hex 32)
+CUSTOMER_INFO=$(cargo run -p kdapp-merchant -- register-customer --customer-private-key "$CUSTOMER_SK")
+echo "$CUSTOMER_INFO"
+CUSTOMER_PK=$(echo "$CUSTOMER_INFO" | grep 'registered customer pubkey' | awk '{print $4}')
+if curl -s -f -H "X-API-Key: $API_KEY" -H "Content-Type: application/json" \
+  -d "{\"subscription_id\":1,\"customer_public_key\":\"$CUSTOMER_PK\",\"amount\":1000,\"interval\":60}" \
+  "http://127.0.0.1:$MERCHANT_PORT/subscribe" >/dev/null; then
+  echo "Seeded demo subscription (id=1)"
+else
+  echo "Failed to seed demo subscription"
+fi
+
 # Launch TUI in foreground
 exec cargo run -p onlykas-tui -- \
   --merchant-url http://127.0.0.1:"$MERCHANT_PORT" \

--- a/examples/onlykas-tui/src/main.rs
+++ b/examples/onlykas-tui/src/main.rs
@@ -322,6 +322,9 @@ async fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: Arc<Mutex<App>>) -
                             tokio::spawn(async move {
                                 App::charge_sub_task(app2, sub_id).await;
                             });
+                        } else {
+                            let mut a = app.lock().await;
+                            a.set_status("no subscription selected".into(), Color::Red);
                         }
                     }
                     Action::None => {}


### PR DESCRIPTION
## Summary
- show a status message when charging a subscription without a selection
- seed demo subscriptions in autopilot scripts for easier testing

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68c7d528df04832b80ea35c3fc6d45d2