### PR TITLE
feat(onlykas-tui): default to ASCII logo unless env 0

### DIFF
--- a/examples/onlykas-tui/README.md
+++ b/examples/onlykas-tui/README.md
@@ -127,7 +127,8 @@ Use `Left`/`Right` to change panels and `Up`/`Down` to navigate items within the
 
 ## Troubleshooting
 - Terminal must support Unicode block characters; without it the UI may misrender.
-- The logo uses Unicode blocks. If it looks misaligned, try a monospace font (Consolas, Cascadia Mono). Or set `ONLYKAS_TUI_ASCII=1` to use a simple ASCII logo.
+- The logo uses Unicode blocks. If it looks misaligned, try a monospace font (Consolas, Cascadia Mono).
+  Set `ONLYKAS_TUI_ASCII=0` to keep the block logo; any other value (or unset) uses a simple ASCII logo.
 - Color: The "KAS" part uses teal (RGB 0,128,128). Some terminals may approximate.
 - Preflight test: run `examples/scripts/smoke_onlykas.sh` to validate merchant+watcher+webhook locally before launching the TUI. It creates an invoice, simulates pay/ack, and checks webhook delivery.
 - Watcher panel shows `null` if the watcher is not running or TUI is not pointed to it. Either run `kdapp-merchant watcher --http-port <P>` and start TUI with `--watcher-url http://127.0.0.1:<P>`, or expose metrics from the merchant process itself.

--- a/examples/onlykas-tui/src/logo.rs
+++ b/examples/onlykas-tui/src/logo.rs
@@ -9,39 +9,41 @@ const LOGO: [&str; 5] = [
 ];
 
 pub fn render_logo() -> Paragraph<'static> {
-    // Find the split point using the first line, then convert to a character
-    // column index so we can safely style per-char on all lines without
-    // splitting at a potentially invalid UTF-8 byte boundary.
-    let k_byte_index = LOGO[0].find("█   ██  ███").unwrap_or(0);
-    let k_col = LOGO[0].char_indices().position(|(i, _)| i == k_byte_index).unwrap_or(0);
-
     let white = Style::default().fg(Color::White).bg(Color::Black).add_modifier(Modifier::BOLD);
     // Teal-ish color (RGB) for better contrast than Cyan on some terminals
     let teal = Style::default().fg(Color::Rgb(0, 128, 128)).bg(Color::Black).add_modifier(Modifier::BOLD);
 
-    // Optional ASCII fallback when block drawing looks bad on some terminals
-    if std::env::var("ONLYKAS_TUI_ASCII").ok().as_deref() == Some("1") {
-        let left = Span::styled("only", white);
-        let right = Span::styled("KAS", teal);
-        let line = Line::from(vec![left, right]);
-        return Paragraph::new(vec![line]).alignment(Alignment::Center);
-    }
+    match std::env::var("ONLYKAS_TUI_ASCII").as_deref() {
+        Ok("0") => {
+            // Find the split point using the first line, then convert to a character
+            // column index so we can safely style per-char on all lines without
+            // splitting at a potentially invalid UTF-8 byte boundary.
+            let k_byte_index = LOGO[0].find("█   ██  ███").unwrap_or(0);
+            let k_col = LOGO[0].char_indices().position(|(i, _)| i == k_byte_index).unwrap_or(0);
 
-    let lines: Vec<Line> = LOGO
-        .iter()
-        .map(|line| {
-            let mut col = 0usize;
-            let spans = line
-                .chars()
-                .map(|c| {
-                    let style = if col < k_col { white } else { teal };
-                    col += 1;
-                    Span::styled(c.to_string(), style)
+            let lines: Vec<Line> = LOGO
+                .iter()
+                .map(|line| {
+                    let mut col = 0usize;
+                    let spans = line
+                        .chars()
+                        .map(|c| {
+                            let style = if col < k_col { white } else { teal };
+                            col += 1;
+                            Span::styled(c.to_string(), style)
+                        })
+                        .collect::<Vec<_>>();
+                    Line::from(spans)
                 })
-                .collect::<Vec<_>>();
-            Line::from(spans)
-        })
-        .collect();
+                .collect();
 
-    Paragraph::new(lines).alignment(Alignment::Center)
+            Paragraph::new(lines).alignment(Alignment::Center)
+        }
+        _ => {
+            let left = Span::styled("only", white);
+            let right = Span::styled("KAS", teal);
+            let line = Line::from(vec![left, right]);
+            Paragraph::new(vec![line]).alignment(Alignment::Center)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- match ONLYKAS_TUI_ASCII env var so any value other than `0` renders ASCII
- document new ONLYKAS_TUI_ASCII behavior in TUI README

## Testing
- N/A: cargo commands are user-run according to repository guidelines

------
https://chatgpt.com/codex/tasks/task_e_68c7eb7cc1f4832b81e13674343db3c6