### PR TITLE
feat(proxy): add tx output cache controls

### DIFF
--- a/kdapp/Cargo.toml
+++ b/kdapp/Cargo.toml
@@ -28,6 +28,7 @@ env_logger.workspace = true
 thiserror.workspace = true
 # parking_lot.workspace = true
 rand.workspace = true
+lru = "0.12"
 # rayon.workspace = true
 secp256k1 = { workspace = true, features = ["global-context", "rand-std", "serde"] }
 sha2.workspace = true


### PR DESCRIPTION
## Summary
- wrap proxy transaction output lookups in an LRU cache keyed by (txid, vout) with configurable defaults
- expose cache tuning through `ProxyCacheConfig` and new kdapp-merchant CLI flags to size or disable the cache
- cover the cache behavior with unit tests and add the `lru` dependency

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68c901021270832bb2cada45e5e87967