### PR TITLE
feat(merchant): secure policy endpoints and template storage

### DIFF
--- a/config/merchant-policy.md
+++ b/config/merchant-policy.md
@@ -1,0 +1,48 @@
+# Merchant Policy API Notes
+
+This document summarizes how the OnlyKAS merchant HTTP server protects the
+policy-management endpoints that were added for runtime configuration.
+
+## Authentication
+
+Policy endpoints accept either of the following credentials:
+
+- **API key** – include `X-API-Key: <token>` in the request headers. The token
+  must match the value supplied on `kdapp-merchant serve --api-key`.
+- **Session token** – present a token issued by an external authentication flow
+  using one of these channels:
+  - `Authorization: Bearer <token>`
+  - `X-Session-Token: <token>`
+  - `Cookie: merchant_session=<token>`
+
+Session tokens are hashed with SHA-256 before being stored in sled. Use
+`storage::store_session_token` (or an equivalent administrative task) to seed
+valid session handles. Tokens can be revoked with
+`storage::remove_session_token`. Requests without a recognised credential are
+rejected with `401 Unauthorized`.
+
+## Script template schema
+
+`POST /policy/templates` upserts script templates that the episode enforces
+against incoming payments. Payloads must conform to the JSON schema below:
+
+```json
+{
+  "template_id": "merchant_p2pk",
+  "script_hex": "4104...ac",
+  "description": "Optional operator notes"
+}
+```
+
+Validation rules:
+
+- `template_id` **must** be one of `merchant_p2pk`,
+  `merchant_guardian_multisig`, or `merchant_taproot`.
+- `script_hex` must decode to non-empty bytes. The server normalizes pushes so
+  equivalent encodings collapse to a canonical form before storage.
+- `description` is optional metadata that is persisted verbatim.
+
+Templates can be listed via `GET /policy/templates` and deleted with
+`DELETE /policy/templates/{template_id}`. All policy routes require the
+authentication described above and will return `403 Forbidden` when a template
+identifier falls outside the whitelist.

--- a/examples/kdapp-merchant/README.md
+++ b/examples/kdapp-merchant/README.md
@@ -97,7 +97,14 @@ kdapp-merchant serve \
   --merchant-private-key <hex>
 ```
 
-Endpoints use `x-api-key` for authentication:
+Endpoints require authentication via either:
+
+- `X-API-Key: <token>` matching the configured server API key, or
+- a valid session token presented as `Authorization: Bearer <token>`,
+  `X-Session-Token: <token>`, or a `merchant_session=<token>` cookie.
+
+Policy endpoints accept the same credentials, enabling UI clients that rely on
+session tokens issued by an authentication flow.
 
 | Endpoint | Description |
 | -------- | ----------- |
@@ -112,6 +119,30 @@ Endpoints use `x-api-key` for authentication:
 | `GET /subscriptions` | List subscriptions |
 | `POST /watcher-config` | Override watcher `max_fee` or `congestion_threshold` |
 | `GET /mempool-metrics` | Fetch mempool metrics snapshot |
+| `POST /policy/templates` | Upsert an allowed script template `{template_id, script_hex, description?}` |
+| `GET /policy/templates` | List stored script templates |
+| `DELETE /policy/templates/:id` | Remove a stored script template |
+
+### Script template schema
+
+`POST /policy/templates` accepts JSON payloads shaped as:
+
+```json
+{
+  "template_id": "merchant_p2pk",
+  "script_hex": "4104...ac",
+  "description": "Optional operator notes"
+}
+```
+
+- `template_id` must match the whitelist: `merchant_p2pk`,
+  `merchant_guardian_multisig`, or `merchant_taproot`.
+- `script_hex` is the canonical hex encoding of the script template that will be
+  enforced when invoices are paid.
+- `description` is optional and stored verbatim for operator reference.
+
+Session tokens are stored hashed on disk. Seed them via an administrative task
+or an authentication integration before relying on session-based access.
 
 Example usage:
 


### PR DESCRIPTION
## Summary
- enforce API key or session-token authentication on the policy routes and expose endpoints to manage script templates
- persist templates in sled with whitelist validation and hash-backed session token storage helpers
- document the updated authentication flow and template schema in the README and `config/merchant-policy.md`

## Testing
- not run (per repository instructions)


------
https://chatgpt.com/codex/tasks/task_e_68c9194201c8832b9df282997901bfd6