### PR TITLE
feat(proxy): propagate tx status metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ clap = { version = "4.5.40", features = ["derive", "string", "cargo"] }
 # utoipa-axum = "0.2.0"
 serde = { version = "1.0.217", features = ["derive"] }
 # serde_with = { version = "3.12.0", features = ["hex", "macros"] }
-# serde_json = "1.0.138"
+serde_json = "1.0.138"
 # sysinfo = "0.34.1"
 # bytesize = "2.0.1"
 # humantime = "2.2.0"

--- a/examples/comment-board/src/comments.rs
+++ b/examples/comment-board/src/comments.rs
@@ -390,6 +390,7 @@ mod tests {
             accepting_time: 1000,
             tx_id: 1u64.into(),
             tx_outputs: None,
+            tx_status: None,
         };
 
         let mut board = CommentBoard::initialize(vec![pk1, pk2], &metadata);
@@ -413,6 +414,7 @@ mod tests {
             accepting_time: 1000,
             tx_id: 1u64.into(),
             tx_outputs: None,
+            tx_status: None,
         };
 
         let mut board = CommentBoard::initialize(vec![pk1, pk2], &metadata);
@@ -453,6 +455,7 @@ mod tests {
             accepting_time: 1000,
             tx_id: 1u64.into(),
             tx_outputs: None,
+            tx_status: None,
         };
 
         let mut board = CommentBoard::initialize(vec![pk1, pk2], &metadata);

--- a/examples/comment-it/src/api/http/blockchain_engine.rs
+++ b/examples/comment-it/src/api/http/blockchain_engine.rs
@@ -341,7 +341,7 @@ impl AuthHttpPeer {
                 accepting_hash,
                 accepting_daa,
                 accepting_time,
-                associated_txs: vec![(KaspaHash::from_bytes([0u8; 32]), payload, None)],
+                associated_txs: vec![(KaspaHash::from_bytes([0u8; 32]), payload, None, None)],
             };
             let _ = sender.send(msg);
             count += 1;

--- a/examples/comment-it/src/cli/commands/demo.rs
+++ b/examples/comment-it/src/cli/commands/demo.rs
@@ -25,6 +25,7 @@ pub fn test_episode_logic(participant_count: usize) -> Result<(), Box<dyn Error>
         accepting_time: std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs(),
         tx_id: 1u64.into(),
         tx_outputs: None,
+        tx_status: None,
     };
 
     // Initialize episode
@@ -109,6 +110,7 @@ pub fn run_interactive_demo() -> Result<(), Box<dyn Error>> {
         accepting_time: std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs(),
         tx_id: 1u64.into(),
         tx_outputs: None,
+        tx_status: None,
     };
 
     // Initialize episode with both participants

--- a/examples/comment-it/src/comment.rs
+++ b/examples/comment-it/src/comment.rs
@@ -314,6 +314,7 @@ mod tests {
             accepting_time: 1234567890,
             tx_id: 1u64.into(),
             tx_outputs: None,
+            tx_status: None,
         };
 
         let episode = CommentEpisode::initialize(vec![p1, p2], &metadata);
@@ -333,6 +334,7 @@ mod tests {
             accepting_time: 1234567890,
             tx_id: 1u64.into(),
             tx_outputs: None,
+            tx_status: None,
         };
 
         let mut episode = CommentEpisode::initialize(vec![p1], &metadata);
@@ -372,6 +374,7 @@ mod tests {
             accepting_time: 1234567890,
             tx_id: 1u64.into(),
             tx_outputs: None,
+            tx_status: None,
         };
 
         let mut episode = CommentEpisode::initialize(vec![p1], &metadata);
@@ -397,6 +400,7 @@ mod tests {
             accepting_time: 1234567890,
             tx_id: 1u64.into(),
             tx_outputs: None,
+            tx_status: None,
         };
 
         let mut episode = CommentEpisode::initialize(vec![p1], &metadata);

--- a/examples/comment-it/src/core/episode.rs
+++ b/examples/comment-it/src/core/episode.rs
@@ -382,8 +382,14 @@ mod tests {
     #[test]
     fn test_auth_challenge_flow() {
         let ((_s1, p1), (_s2, _p2)) = (generate_keypair(), generate_keypair());
-        let metadata =
-            PayloadMetadata { accepting_hash: 0u64.into(), accepting_daa: 0, accepting_time: 0, tx_id: 1u64.into(), tx_outputs: None };
+        let metadata = PayloadMetadata {
+            accepting_hash: 0u64.into(),
+            accepting_daa: 0,
+            accepting_time: 0,
+            tx_id: 1u64.into(),
+            tx_outputs: None,
+            tx_status: None,
+        };
 
         let mut auth = AuthWithCommentsEpisode::initialize(vec![p1], &metadata);
 
@@ -401,8 +407,14 @@ mod tests {
     #[test]
     fn test_rate_limiting() {
         let ((_s1, p1), (_s2, _p2)) = (generate_keypair(), generate_keypair());
-        let metadata =
-            PayloadMetadata { accepting_hash: 0u64.into(), accepting_daa: 0, accepting_time: 0, tx_id: 1u64.into(), tx_outputs: None };
+        let metadata = PayloadMetadata {
+            accepting_hash: 0u64.into(),
+            accepting_daa: 0,
+            accepting_time: 0,
+            tx_id: 1u64.into(),
+            tx_outputs: None,
+            tx_status: None,
+        };
 
         let mut auth = AuthWithCommentsEpisode::initialize(vec![p1], &metadata);
 
@@ -433,6 +445,7 @@ mod tests {
             accepting_time: 1234567890,
             tx_id: 1u64.into(),
             tx_outputs: None,
+            tx_status: None,
         };
 
         let mut auth = AuthWithCommentsEpisode::initialize(vec![p1], &metadata);

--- a/examples/kas-draw/src/offchain.rs
+++ b/examples/kas-draw/src/offchain.rs
@@ -174,7 +174,7 @@ impl OffchainRouter {
                     accepting_hash,
                     accepting_daa: msg.seq,
                     accepting_time: now_secs,
-                    associated_txs: vec![(tx_id, payload, None::<Vec<TxOutputInfo>>)],
+                    associated_txs: vec![(tx_id, payload, None::<Vec<TxOutputInfo>>, None)],
                 };
                 if let Err(e) = self.sender.send(event) {
                     warn!("router: failed forwarding to engine: {e}");

--- a/examples/kaspa-auth/src/api/http/handlers/challenge.rs
+++ b/examples/kaspa-auth/src/api/http/handlers/challenge.rs
@@ -28,6 +28,7 @@ pub async fn request_challenge(
                 accepting_time: 0,
                 tx_id: episode_id.into(),
                 tx_outputs: None,
+                tx_status: None,
             };
             match episode.execute(&challenge_cmd, episode.owner, &metadata) {
                 Ok(_) => {

--- a/examples/kaspa-auth/src/api/http/handlers/verify.rs
+++ b/examples/kaspa-auth/src/api/http/handlers/verify.rs
@@ -62,6 +62,7 @@ pub async fn verify_auth(State(state): State<PeerState>, Json(req): Json<VerifyR
                 accepting_time: 0,
                 tx_id: episode_id.into(),
                 tx_outputs: None,
+                tx_status: None,
             };
             // Execute the authentication command in memory
             let _ = episode.execute(

--- a/examples/kaspa-auth/src/core/episode.rs
+++ b/examples/kaspa-auth/src/core/episode.rs
@@ -249,8 +249,14 @@ mod tests {
     #[test]
     fn test_auth_challenge_flow() {
         let ((_s1, p1), (_s2, _p2)) = (generate_keypair(), generate_keypair());
-        let metadata =
-            PayloadMetadata { accepting_hash: 0u64.into(), accepting_daa: 0, accepting_time: 0, tx_id: 1u64.into(), tx_outputs: None };
+        let metadata = PayloadMetadata {
+            accepting_hash: 0u64.into(),
+            accepting_daa: 0,
+            accepting_time: 0,
+            tx_id: 1u64.into(),
+            tx_outputs: None,
+            tx_status: None,
+        };
 
         let mut auth = SimpleAuth::initialize(vec![p1], &metadata);
 
@@ -268,8 +274,14 @@ mod tests {
     #[test]
     fn test_rate_limiting() {
         let ((_s1, p1), (_s2, _p2)) = (generate_keypair(), generate_keypair());
-        let metadata =
-            PayloadMetadata { accepting_hash: 0u64.into(), accepting_daa: 0, accepting_time: 0, tx_id: 1u64.into(), tx_outputs: None };
+        let metadata = PayloadMetadata {
+            accepting_hash: 0u64.into(),
+            accepting_daa: 0,
+            accepting_time: 0,
+            tx_id: 1u64.into(),
+            tx_outputs: None,
+            tx_status: None,
+        };
 
         let mut auth = SimpleAuth::initialize(vec![p1], &metadata);
 

--- a/examples/kdapp-customer/src/episode.rs
+++ b/examples/kdapp-customer/src/episode.rs
@@ -243,6 +243,7 @@ mod tests {
             accepting_time: 0,
             tx_id: Hash::default(),
             tx_outputs: None,
+            tx_status: None,
         }
     }
 

--- a/examples/kdapp-mcp-server/src/tools.rs
+++ b/examples/kdapp-mcp-server/src/tools.rs
@@ -44,6 +44,7 @@ pub async fn start_episode(state: Arc<ServerState>, participants: Vec<String>) -
         accepting_time: 0,
         tx_id: Hash::default(),
         tx_outputs: None,
+        tx_status: None,
     };
 
     // Create the episode message
@@ -56,7 +57,7 @@ pub async fn start_episode(state: Arc<ServerState>, participants: Vec<String>) -
         accepting_hash: Hash::default(),
         accepting_daa: 0,
         accepting_time: 0,
-        associated_txs: vec![(Hash::default(), borsh::to_vec(&episode_message).unwrap(), None)],
+        associated_txs: vec![(Hash::default(), borsh::to_vec(&episode_message).unwrap(), None, None)],
     };
 
     // Send the message to the engine
@@ -189,7 +190,7 @@ pub async fn execute_command(
         accepting_hash: Hash::default(),
         accepting_daa: 0,
         accepting_time: 0,
-        associated_txs: vec![(Hash::default(), borsh::to_vec(&signed).unwrap(), None)],
+        associated_txs: vec![(Hash::default(), borsh::to_vec(&signed).unwrap(), None, None)],
     };
 
     // Send the message to the engine

--- a/examples/kdapp-merchant/src/episode.rs
+++ b/examples/kdapp-merchant/src/episode.rs
@@ -479,6 +479,7 @@ mod tests {
             accepting_time: 1,
             tx_id: Hash::default(),
             tx_outputs: None,
+            tx_status: None,
         }
     }
 

--- a/examples/kdapp-merchant/src/sim_router.rs
+++ b/examples/kdapp-merchant/src/sim_router.rs
@@ -41,7 +41,7 @@ impl SimRouter {
             accepting_hash,
             accepting_daa: 0,
             accepting_time: now,
-            associated_txs: vec![(tx_id, payload, None::<Vec<TxOutputInfo>>)],
+            associated_txs: vec![(tx_id, payload, None::<Vec<TxOutputInfo>>, None)],
         };
         self.sender.send(event)
     }

--- a/examples/kdapp-merchant/src/tcp_router.rs
+++ b/examples/kdapp-merchant/src/tcp_router.rs
@@ -151,7 +151,7 @@ impl TcpRouter {
                     accepting_hash,
                     accepting_daa: msg.seq,
                     accepting_time: now_secs,
-                    associated_txs: vec![(tx_id, msg.payload, None::<Vec<TxOutputInfo>>)],
+                    associated_txs: vec![(tx_id, msg.payload, None::<Vec<TxOutputInfo>>, None)],
                 };
                 if let Err(e) = self.sender.send(event) {
                     warn!("router: failed forwarding to engine: {e}");

--- a/examples/kdapp-merchant/src/udp_router.rs
+++ b/examples/kdapp-merchant/src/udp_router.rs
@@ -154,7 +154,7 @@ impl UdpRouter {
                     accepting_hash,
                     accepting_daa: msg.seq,
                     accepting_time: now_secs,
-                    associated_txs: vec![(tx_id, msg.payload, None::<Vec<TxOutputInfo>>)],
+                    associated_txs: vec![(tx_id, msg.payload, None::<Vec<TxOutputInfo>>, None)],
                 };
                 if let Err(e) = self.sender.send(event) {
                     warn!("router: failed forwarding to engine: {e}");

--- a/examples/kdapp-merchant/src/watcher.rs
+++ b/examples/kdapp-merchant/src/watcher.rs
@@ -305,7 +305,7 @@ pub async fn relay_checkpoints(
                                 accepting_hash,
                                 accepting_daa,
                                 accepting_time,
-                                associated_txs: vec![(tx_id, payload.to_vec(), None::<Vec<TxOutputInfo>>)],
+                                associated_txs: vec![(tx_id, payload.to_vec(), None::<Vec<TxOutputInfo>>, None)],
                             };
                             let _ = sender.send(event);
                         }

--- a/examples/kdapp-merchant/tests/fixtures.rs
+++ b/examples/kdapp-merchant/tests/fixtures.rs
@@ -35,6 +35,7 @@ pub fn setup() -> TestContext {
         accepting_time: 1,
         tx_id: Hash::default(),
         tx_outputs: None,
+        tx_status: None,
     };
 
     let mut episode = ReceiptEpisode::initialize(vec![merchant_pk], &metadata);

--- a/examples/tictactoe/src/game.rs
+++ b/examples/tictactoe/src/game.rs
@@ -249,7 +249,14 @@ mod tests {
     fn test_ttt_rollback() {
         let ((_s1, p1), (_s2, p2)) = (generate_keypair(), generate_keypair());
         let metadata =
-            PayloadMetadata { accepting_hash: 0u64.into(), accepting_daa: 0, accepting_time: 0, tx_id: 1u64.into(), tx_outputs: None };
+            PayloadMetadata {
+                accepting_hash: 0u64.into(),
+                accepting_daa: 0,
+                accepting_time: 0,
+                tx_id: 1u64.into(),
+                tx_outputs: None,
+                tx_status: None,
+            };
         let mut game = TicTacToe::initialize(vec![p1, p2], &metadata);
         let rollback = game.execute(&TTTMove { row: 0, col: 0 }, Some(p1), &metadata).unwrap();
         game.rollback(rollback);
@@ -332,7 +339,7 @@ mod tests {
                 accepting_hash: 1u64.into(),
                 accepting_daa: 0,
                 accepting_time: 0,
-                associated_txs: vec![(2u64.into(), payload, None)],
+                associated_txs: vec![(2u64.into(), payload, None, None)],
             })
             .unwrap();
 
@@ -347,7 +354,7 @@ mod tests {
                 accepting_hash: 3u64.into(),
                 accepting_daa: 1,
                 accepting_time: 1,
-                associated_txs: vec![(4u64.into(), payload, None)],
+                associated_txs: vec![(4u64.into(), payload, None, None)],
             })
             .unwrap();
 
@@ -359,7 +366,7 @@ mod tests {
                 accepting_hash: 5u64.into(),
                 accepting_daa: 2,
                 accepting_time: 2,
-                associated_txs: vec![(4u64.into(), payload, None)],
+                associated_txs: vec![(4u64.into(), payload, None, None)],
             })
             .unwrap();
 

--- a/kdapp/Cargo.toml
+++ b/kdapp/Cargo.toml
@@ -34,6 +34,7 @@ secp256k1 = { workspace = true, features = ["global-context", "rand-std", "serde
 sha2.workspace = true
 tokio = { workspace = true, features = ["rt", "macros", "rt-multi-thread", "net"] }
 serde.workspace = true
+serde_json.workspace = true
 
 [features]
 default = []

--- a/kdapp/src/episode.rs
+++ b/kdapp/src/episode.rs
@@ -1,6 +1,6 @@
 //! Defines the external injection points an Episode developer would need to implement
 
-use crate::pki::PubKey;
+use crate::{pki::PubKey, proxy::TxStatus};
 use borsh::{BorshDeserialize, BorshSerialize};
 use kaspa_consensus_core::Hash;
 use std::error::Error;
@@ -38,6 +38,7 @@ pub struct PayloadMetadata {
     pub tx_id: Hash,
     // Optional carrier transaction context (selected fields only)
     pub tx_outputs: Option<Vec<TxOutputInfo>>,
+    pub tx_status: Option<TxStatus>,
 }
 
 pub type EpisodeId = u32;


### PR DESCRIPTION
## Summary
- parse transaction status details in the proxy and forward them to engines via the new `TxStatus` structure
- extend engine payload metadata and sample routers to carry the optional status data alongside payload outputs
- cover the JSON parsing path with unit tests and add the serde_json dependency required for status handling

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68ca59ecc2fc832b81cba21cf9decc1f