### PR TITLE
fix(proxy): derive tx status from dag info

### DIFF
--- a/examples/kdapp-merchant/Cargo.toml
+++ b/examples/kdapp-merchant/Cargo.toml
@@ -33,6 +33,7 @@ hex = "0.4"
 ctrlc = "3.4"
 
 [dev-dependencies]
+tempfile = "3.10"
 
 [features]
 okcp_relay = []


### PR DESCRIPTION
## Summary
- derive TxStatus metadata from block header and virtual DAA score instead of scraping missing RPC fields
- refresh the cached virtual DAA score on each batch so confirmations/finality are computed correctly and cover it with unit tests
- gate watcher relay imports behind feature/test cfgs and fix the Kaspa hash import so the example compiles again

## Testing
- not run (per repository instructions)


------
https://chatgpt.com/codex/tasks/task_e_68ca637f7eb4832bb1eabccdd54e9836