### PR TITLE
fix: resolve clippy issues in merchant examples

### DIFF
--- a/examples/kdapp-merchant/src/watcher.rs
+++ b/examples/kdapp-merchant/src/watcher.rs
@@ -403,10 +403,10 @@ pub async fn relay_checkpoints(
     }
 }
 
-#[cfg(any(test, feature = "okcp_relay"))]
+#[cfg(feature = "okcp_relay")]
 const DEFAULT_RELAY_STATE_FILE: &str = "okcp_relay_state.hex";
 
-#[cfg(any(test, feature = "okcp_relay"))]
+#[cfg(feature = "okcp_relay")]
 fn default_state_path() -> PathBuf {
     PathBuf::from(DEFAULT_RELAY_STATE_FILE)
 }
@@ -463,7 +463,7 @@ impl RelayCheckpointStore {
     }
 }
 
-#[cfg(any(test, feature = "okcp_relay"))]
+#[cfg(feature = "okcp_relay")]
 fn batch_from_notification_block(block: kaspa_consensus_core::block::Block, program_id: u64) -> Option<CheckpointBatch> {
     let accepting_hash = block.hash();
     let accepting_daa = block.header.daa_score;
@@ -483,7 +483,7 @@ fn batch_from_notification_block(block: kaspa_consensus_core::block::Block, prog
     build_checkpoint_batch(accepting_hash, accepting_daa, accepting_time, checkpoints)
 }
 
-#[cfg(any(test, feature = "okcp_relay"))]
+#[cfg(feature = "okcp_relay")]
 fn batch_from_rpc_block(block: RpcBlock, program_id: u64) -> Option<CheckpointBatch> {
     use std::convert::TryFrom;
 
@@ -515,7 +515,7 @@ fn batch_from_rpc_block(block: RpcBlock, program_id: u64) -> Option<CheckpointBa
     build_checkpoint_batch(accepting_hash, accepting_daa, accepting_time, checkpoints)
 }
 
-#[cfg(any(test, feature = "okcp_relay"))]
+#[cfg(feature = "okcp_relay")]
 fn build_checkpoint_batch(
     accepting_hash: Hash,
     accepting_daa: u64,
@@ -564,7 +564,7 @@ where
     }
 }
 
-#[cfg(any(test, feature = "okcp_relay"))]
+#[cfg(feature = "okcp_relay")]
 async fn startup_rescan(
     client: &KaspaRpcClient,
     program_id: u64,

--- a/examples/kdapp-merchant/src/webhook.rs
+++ b/examples/kdapp-merchant/src/webhook.rs
@@ -70,6 +70,12 @@ pub struct WebhookEvent {
     pub invoice_id: u64,
     pub amount: u64,
     pub timestamp: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub episode_id: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memo: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payer_pubkey: Option<String>,
 }
 
 #[cfg_attr(not(test), allow(dead_code))]

--- a/examples/kdapp-merchant/tests/fixtures.rs
+++ b/examples/kdapp-merchant/tests/fixtures.rs
@@ -1,5 +1,4 @@
 pub use kdapp_merchant::episode;
-pub use kdapp_merchant::script;
 #[allow(dead_code)]
 pub use kdapp_merchant::storage;
 

--- a/examples/kdapp-merchant/tests/webhook_tests.rs
+++ b/examples/kdapp-merchant/tests/webhook_tests.rs
@@ -14,7 +14,7 @@ use hmac::{Hmac, Mac};
 use sha2::Sha256;
 use tokio::net::TcpListener;
 use kdapp::proxy::TxStatus;
-use kdapp_merchant::webhook::{self, post_event, ConfirmationPolicy, WebhookError, WebhookEvent};
+use kdapp_merchant::webhook::{post_event, ConfirmationPolicy, WebhookError, WebhookEvent};
 
 #[derive(Clone)]
 struct AppState {
@@ -55,7 +55,15 @@ async fn retries_on_5xx() {
     let addr = listener.local_addr().unwrap();
     tokio::spawn(async move { axum::serve(listener, app.into_make_service()).await.unwrap() });
 
-    let event = WebhookEvent { event: "paid".into(), invoice_id: 1, amount: 100, timestamp: 1 };
+    let event = WebhookEvent {
+        event: "paid".into(),
+        invoice_id: 1,
+        amount: 100,
+        timestamp: 1,
+        episode_id: None,
+        memo: None,
+        payer_pubkey: None,
+    };
     let url = format!("http://{addr}");
     post_event(&url, b"topsecret", &event).await.unwrap();
     assert_eq!(attempts.load(Ordering::SeqCst), 2);
@@ -70,7 +78,15 @@ async fn no_retry_on_4xx() {
     let addr = listener.local_addr().unwrap();
     tokio::spawn(async move { axum::serve(listener, app.into_make_service()).await.unwrap() });
 
-    let event = WebhookEvent { event: "paid".into(), invoice_id: 1, amount: 100, timestamp: 1 };
+    let event = WebhookEvent {
+        event: "paid".into(),
+        invoice_id: 1,
+        amount: 100,
+        timestamp: 1,
+        episode_id: None,
+        memo: None,
+        payer_pubkey: None,
+    };
     let url = format!("http://{addr}");
     let err = post_event(&url, b"topsecret", &event).await.unwrap_err();
     match err {

--- a/examples/tests/watcher_config.rs
+++ b/examples/tests/watcher_config.rs
@@ -1,4 +1,4 @@
-use std::sync::{mpsc, Mutex, OnceLock};
+use std::sync::{mpsc, OnceLock};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -13,10 +13,11 @@ use kdapp_merchant::watcher::{self, MempoolSnapshot, PolicySnapshot, MIN_FEE};
 use serde::Deserialize;
 use serde_json::Value;
 use tower::ServiceExt;
+use tokio::sync::Mutex;
 
-fn test_guard() -> std::sync::MutexGuard<'static, ()> {
+async fn test_guard() -> tokio::sync::MutexGuard<'static, ()> {
     static GUARD: OnceLock<Mutex<()>> = OnceLock::new();
-    GUARD.get_or_init(|| Mutex::new(())).lock().unwrap()
+    GUARD.get_or_init(|| Mutex::new(())).lock().await
 }
 
 fn init_policy(max_fee: u64, threshold: f64) {
@@ -147,7 +148,7 @@ async fn post_rollback(router: &Router, op_id: u64) -> StatusCode {
 
 #[tokio::test]
 async fn watcher_config_applied_on_success() {
-    let _g = test_guard();
+    let _g = test_guard().await;
     init_policy(MIN_FEE, 1.0);
     let state = test_state();
     let router = router_with_state(state);
@@ -173,11 +174,13 @@ async fn watcher_config_applied_on_success() {
     let last = state.history.last().expect("history entry");
     assert_eq!(last.status, TestStatus::Applied);
     assert_eq!(last.target_max_fee, Some(desired_fee));
+    assert_eq!(last.target_congestion_threshold, Some(desired_threshold));
+    assert_eq!(state.current_congestion_threshold, Some(desired_threshold));
 }
 
 #[tokio::test]
 async fn watcher_config_times_out_without_metrics() {
-    let _g = test_guard();
+    let _g = test_guard().await;
     init_policy(MIN_FEE, 1.0);
     let router = router_with_state(test_state());
 
@@ -191,11 +194,13 @@ async fn watcher_config_times_out_without_metrics() {
     let pending = state.pending.expect("pending op");
     assert_eq!(pending.status, TestStatus::TimedOut);
     assert_eq!(pending.op_id, op.op_id);
+    assert!(pending.target_congestion_threshold.is_none());
+    assert_eq!(state.current_congestion_threshold, Some(1.0));
 }
 
 #[tokio::test]
 async fn watcher_config_manual_revert_clears_timeout() {
-    let _g = test_guard();
+    let _g = test_guard().await;
     init_policy(MIN_FEE, 1.0);
     let router = router_with_state(test_state());
 
@@ -210,6 +215,10 @@ async fn watcher_config_manual_revert_clears_timeout() {
     let state = get_state(&router).await;
     assert_eq!(state.pending.as_ref().map(|p| p.status.clone()), Some(TestStatus::TimedOut));
     assert_eq!(state.pending.as_ref().map(|p| p.op_id), Some(op.op_id));
+    assert_eq!(
+        state.pending.as_ref().and_then(|p| p.target_congestion_threshold),
+        Some(0.2)
+    );
 
     let rollback_status = post_rollback(&router, op.op_id).await;
     assert_eq!(rollback_status, StatusCode::OK);
@@ -219,4 +228,5 @@ async fn watcher_config_manual_revert_clears_timeout() {
     let last = state.history.last().expect("history entry");
     assert_eq!(last.status, TestStatus::RolledBack);
     assert!(state.current_max_fee.is_none());
+    assert!(state.current_congestion_threshold.is_none());
 }


### PR DESCRIPTION
## Summary
- reuse the webhook client for server webhooks and extend WebhookEvent metadata
- convert watcher config tests to use an async mutex guard and verify additional threshold fields
- simplify merchant reorg test helpers and gate relay-only helpers behind the okcp_relay feature

## Testing
- Not run (per guidelines)

------
https://chatgpt.com/codex/tasks/task_e_68cad4872b58832bb89893f936e1bd0e