### PR TITLE
Add offline integration test harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2509,6 +2509,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "integration-tests"
+version = "0.0.1"
+dependencies = [
+ "borsh",
+ "kdapp",
+ "kaspa-addresses",
+ "kaspa-consensus-core",
+ "kaspa-txscript",
+ "rand 0.8.5",
+ "secp256k1",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "kdapp"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "examples/kdapp-guardian",
     "examples/tests",
     "examples/onlykas-tui",
+    "integration-tests",
 ]
 
 

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "integration-tests"
+version = "0.0.1"
+edition = "2021"
+publish = false
+
+[dependencies]
+thiserror = { workspace = true }
+
+[dev-dependencies]
+kdapp = { workspace = true }
+borsh = { workspace = true }
+kaspa-addresses = { workspace = true }
+kaspa-consensus-core = { workspace = true }
+kaspa-txscript = { workspace = true }
+secp256k1 = { workspace = true }
+rand = { workspace = true }

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -1,0 +1,3 @@
+//! Shared utilities for kdapp integration tests.
+
+pub mod support;

--- a/integration-tests/src/support.rs
+++ b/integration-tests/src/support.rs
@@ -1,0 +1,200 @@
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::{Arc, Mutex};
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use kdapp::engine::{EngineMsg, EpisodeMessage};
+use kdapp::episode::{Episode, EpisodeError, EpisodeEventHandler, EpisodeId, PayloadMetadata, TxOutputInfo};
+use kdapp::pki::PubKey;
+use kdapp::proxy::TxStatus;
+use kaspa_consensus_core::Hash;
+use std::sync::mpsc::Sender;
+use thiserror::Error;
+
+#[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub enum TestCommand {
+    Add(u32),
+}
+
+#[derive(Clone, Debug, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
+pub struct TestRollback {
+    previous_value: u32,
+}
+
+#[derive(Debug, Error)]
+pub enum TestError {
+    #[error("command would overflow episode state")]
+    Overflow,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct TestEpisode {
+    pub authorized: Vec<PubKey>,
+    value: u32,
+    executed: Vec<u32>,
+}
+
+impl TestEpisode {
+    pub fn value(&self) -> u32 {
+        self.value
+    }
+}
+
+impl Episode for TestEpisode {
+    type Command = TestCommand;
+    type CommandRollback = TestRollback;
+    type CommandError = TestError;
+
+    fn initialize(participants: Vec<PubKey>, _metadata: &PayloadMetadata) -> Self {
+        Self { authorized: participants, value: 0, executed: Vec::new() }
+    }
+
+    fn execute(
+        &mut self,
+        cmd: &Self::Command,
+        authorization: Option<PubKey>,
+        _metadata: &PayloadMetadata,
+    ) -> Result<Self::CommandRollback, EpisodeError<Self::CommandError>> {
+        if let Some(auth) = authorization {
+            if !self.authorized.iter().any(|pk| pk == &auth) {
+                return Err(EpisodeError::Unauthorized);
+            }
+        }
+
+        match cmd {
+            TestCommand::Add(delta) => {
+                let new_value = self
+                    .value
+                    .checked_add(*delta)
+                    .ok_or_else(|| EpisodeError::InvalidCommand(TestError::Overflow))?;
+                let rollback = TestRollback { previous_value: self.value };
+                self.value = new_value;
+                self.executed.push(*delta);
+                Ok(rollback)
+            }
+        }
+    }
+
+    fn rollback(&mut self, rollback: Self::CommandRollback) -> bool {
+        if self.executed.pop().is_none() && self.value != rollback.previous_value {
+            return false;
+        }
+        self.value = rollback.previous_value;
+        true
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct HandlerState {
+    pub initializations: Vec<InitEvent>,
+    pub commands: Vec<CommandEvent>,
+    pub rollbacks: Vec<RollbackEvent>,
+}
+
+#[derive(Clone, Debug)]
+pub struct InitEvent {
+    pub episode_id: EpisodeId,
+    pub value: u32,
+    pub metadata: PayloadMetadata,
+}
+
+#[derive(Clone, Debug)]
+pub struct CommandEvent {
+    pub episode_id: EpisodeId,
+    pub command: TestCommand,
+    pub value: u32,
+    pub authorization: Option<PubKey>,
+    pub metadata: PayloadMetadata,
+}
+
+#[derive(Clone, Debug)]
+pub struct RollbackEvent {
+    pub episode_id: EpisodeId,
+    pub value: u32,
+}
+
+#[derive(Clone, Default)]
+pub struct RecordingHandler {
+    state: Arc<Mutex<HandlerState>>,
+}
+
+impl RecordingHandler {
+    pub fn new() -> (Self, Arc<Mutex<HandlerState>>) {
+        let state = Arc::new(Mutex::new(HandlerState::default()));
+        (Self { state: Arc::clone(&state) }, state)
+    }
+}
+
+impl EpisodeEventHandler<TestEpisode> for RecordingHandler {
+    fn on_initialize(&self, episode_id: EpisodeId, episode: &TestEpisode) {
+        let mut guard = self.state.lock().expect("handler state poisoned");
+        guard.initializations.push(InitEvent { episode_id, value: episode.value(), metadata: empty_metadata() });
+    }
+
+    fn on_command(
+        &self,
+        episode_id: EpisodeId,
+        episode: &TestEpisode,
+        cmd: &TestCommand,
+        authorization: Option<PubKey>,
+        metadata: &PayloadMetadata,
+    ) {
+        let mut guard = self.state.lock().expect("handler state poisoned");
+        guard.commands.push(CommandEvent {
+            episode_id,
+            command: cmd.clone(),
+            value: episode.value(),
+            authorization,
+            metadata: metadata.clone(),
+        });
+    }
+
+    fn on_rollback(&self, episode_id: EpisodeId, episode: &TestEpisode) {
+        let mut guard = self.state.lock().expect("handler state poisoned");
+        guard.rollbacks.push(RollbackEvent { episode_id, value: episode.value() });
+    }
+}
+
+pub fn handler_state_snapshot(state: &Arc<Mutex<HandlerState>>) -> HandlerState {
+    state.lock().expect("handler state poisoned").clone()
+}
+
+pub fn hash_from_byte(byte: u8) -> Hash {
+    let mut data = [0u8; 32];
+    data[31] = byte;
+    Hash::from_bytes(data)
+}
+
+pub fn next_tx_hash() -> Hash {
+    static COUNTER: AtomicU8 = AtomicU8::new(0);
+    let byte = COUNTER.fetch_add(1, Ordering::Relaxed).wrapping_add(1);
+    hash_from_byte(byte)
+}
+
+pub fn send_block(
+    tx: &Sender<EngineMsg>,
+    accepting_hash: Hash,
+    accepting_daa: u64,
+    accepting_time: u64,
+    entries: Vec<(EpisodeMessage<TestEpisode>, Option<Vec<TxOutputInfo>>, Option<TxStatus>)>,
+) {
+    let associated_txs = entries
+        .into_iter()
+        .map(|(msg, outputs, status)| {
+            let payload = borsh::to_vec(&msg).expect("serialize episode message");
+            (next_tx_hash(), payload, outputs, status)
+        })
+        .collect();
+    let event = EngineMsg::BlkAccepted { accepting_hash, accepting_daa, accepting_time, associated_txs };
+    tx.send(event).expect("send block event");
+}
+
+pub fn empty_metadata() -> PayloadMetadata {
+    PayloadMetadata {
+        accepting_hash: Hash::default(),
+        accepting_daa: 0,
+        accepting_time: 0,
+        tx_id: Hash::default(),
+        tx_outputs: None,
+        tx_status: None,
+    }
+}

--- a/integration-tests/tests/engine_flows.rs
+++ b/integration-tests/tests/engine_flows.rs
@@ -1,0 +1,103 @@
+use std::sync::mpsc::channel;
+use std::thread;
+
+use integration_tests::support::{
+    handler_state_snapshot,
+    hash_from_byte,
+    send_block,
+    HandlerState,
+    RecordingHandler,
+    TestCommand,
+    TestEpisode,
+};
+use kdapp::engine::{Engine, EngineMsg, EpisodeMessage};
+use kdapp::episode::{EpisodeId, TxOutputInfo};
+use kdapp::pki::generate_keypair;
+use kdapp::proxy::TxStatus;
+
+fn append_block(
+    sender: &std::sync::mpsc::Sender<EngineMsg>,
+    accepting_hash: u8,
+    entries: Vec<(EpisodeMessage<TestEpisode>, Option<Vec<TxOutputInfo>>, Option<TxStatus>)>,
+) {
+    send_block(
+        sender,
+        hash_from_byte(accepting_hash),
+        accepting_hash as u64 * 100,
+        accepting_hash as u64 * 10,
+        entries,
+    );
+}
+
+#[test]
+fn engine_processes_signed_unsigned_and_reorgs_without_network() {
+    let (authorized_sk, authorized_pk) = generate_keypair();
+    let (unauthorized_sk, unauthorized_pk) = generate_keypair();
+    let (tx, rx) = channel();
+    let (handler, state) = RecordingHandler::new();
+
+    let mut engine = Engine::<TestEpisode, RecordingHandler>::new(rx);
+    let engine_handle = thread::spawn(move || {
+        engine.start(vec![handler]);
+    });
+
+    let episode_id: EpisodeId = 7;
+
+    append_block(
+        &tx,
+        1,
+        vec![
+            (
+                EpisodeMessage::NewEpisode { episode_id, participants: vec![authorized_pk] },
+                Some(vec![TxOutputInfo { value: 100, script_version: 0, script_bytes: Some(vec![1, 2, 3]) }]),
+                Some(TxStatus { acceptance_height: Some(10), confirmations: Some(1), finality: Some(false) }),
+            ),
+        ],
+    );
+
+    let signed_cmd = EpisodeMessage::new_signed_command(episode_id, TestCommand::Add(5), authorized_sk, authorized_pk);
+    append_block(&tx, 2, vec![(signed_cmd, None, None)]);
+
+    let unauthorized_cmd = EpisodeMessage::new_signed_command(episode_id, TestCommand::Add(3), unauthorized_sk, unauthorized_pk);
+    append_block(&tx, 3, vec![(unauthorized_cmd, None, None)]);
+
+    let unsigned_cmd = EpisodeMessage::UnsignedCommand { episode_id, cmd: TestCommand::Add(7) };
+    append_block(
+        &tx,
+        4,
+        vec![(
+            unsigned_cmd,
+            None,
+            Some(TxStatus { acceptance_height: Some(20), confirmations: Some(5), finality: Some(true) }),
+        )],
+    );
+
+    tx.send(EngineMsg::BlkReverted { accepting_hash: hash_from_byte(4) }).expect("send revert");
+    tx.send(EngineMsg::BlkReverted { accepting_hash: hash_from_byte(3) }).expect("send revert");
+    tx.send(EngineMsg::BlkReverted { accepting_hash: hash_from_byte(2) }).expect("send revert");
+    tx.send(EngineMsg::BlkReverted { accepting_hash: hash_from_byte(1) }).expect("send revert");
+    tx.send(EngineMsg::Exit).expect("send exit");
+
+    engine_handle.join().expect("engine thread");
+
+    let HandlerState { initializations, commands, rollbacks } = handler_state_snapshot(&state);
+
+    assert_eq!(initializations.len(), 1, "episode should be initialized once");
+    assert_eq!(initializations[0].value, 0);
+
+    assert_eq!(commands.len(), 2, "only signed and unsigned commands are accepted");
+    assert_eq!(commands[0].command, TestCommand::Add(5));
+    assert_eq!(commands[0].value, 5);
+    assert_eq!(commands[0].authorization, Some(authorized_pk));
+    assert!(commands[0].metadata.tx_status.is_none());
+
+    assert_eq!(commands[1].command, TestCommand::Add(7));
+    assert_eq!(commands[1].value, 12);
+    assert_eq!(commands[1].authorization, None);
+    assert_eq!(commands[1].metadata.tx_status.as_ref().and_then(|s| s.finality), Some(true));
+
+    assert_eq!(rollbacks.len(), 3, "unsigned, signed, and creation rollbacks recorded");
+    assert_eq!(rollbacks[0].value, 5, "unsigned rollback returns to signed state");
+    assert_eq!(rollbacks[1].value, 0, "signed rollback returns to initial value");
+    assert_eq!(rollbacks[2].value, 0, "episode deletion leaves default state");
+}

--- a/integration-tests/tests/generator_flow.rs
+++ b/integration-tests/tests/generator_flow.rs
@@ -1,0 +1,69 @@
+use integration_tests::support::{hash_from_byte, TestCommand, TestEpisode};
+use kdapp::engine::EpisodeMessage;
+use kdapp::generator::{check_pattern, get_first_output_utxo, Payload, TransactionGenerator, PatternType, PrefixType};
+use kaspa_addresses::{Address, Prefix, Version};
+use kaspa_consensus_core::tx::{TransactionOutpoint, UtxoEntry};
+use kaspa_txscript::pay_to_address_script;
+use rand::rngs::StdRng;
+use rand::{RngCore, SeedableRng};
+use secp256k1::{Keypair, Secp256k1, SecretKey};
+
+fn deterministic_secret(seed: u64) -> SecretKey {
+    let mut rng = StdRng::seed_from_u64(seed);
+    let mut bytes = [0u8; 32];
+    loop {
+        rng.fill_bytes(&mut bytes);
+        if let Ok(secret) = SecretKey::from_slice(&bytes) {
+            return secret;
+        }
+    }
+}
+
+#[test]
+fn generator_builds_payload_and_matches_pattern() {
+    let secp = Secp256k1::new();
+    let secret_key = deterministic_secret(42);
+    let keypair = Keypair::from_secret_key(&secp, &secret_key);
+    let pattern: PatternType = [(0, 0); 10];
+    let prefix: PrefixType = 0xA1B2C3D4;
+
+    let recipient_secret = deterministic_secret(7);
+    let recipient_keypair = Keypair::from_secret_key(&secp, &recipient_secret);
+    let recipient_address = Address::new(Prefix::Testnet, Version::PubKey, &recipient_keypair.x_only_public_key().0.serialize());
+
+    let owner_address = Address::new(Prefix::Testnet, Version::PubKey, &keypair.x_only_public_key().0.serialize());
+    let utxo_amount = 25_000;
+    let utxo = (TransactionOutpoint::new(hash_from_byte(50), 0), UtxoEntry::new(utxo_amount, pay_to_address_script(&owner_address), 0, false));
+
+    let generator = TransactionGenerator::new(keypair, pattern, prefix);
+    let command = EpisodeMessage::<TestEpisode>::UnsignedCommand { episode_id: 9, cmd: TestCommand::Add(2) };
+    let fee = 500;
+    let tx = generator.build_command_transaction(utxo.clone(), &recipient_address, &command, fee);
+
+    assert!(check_pattern(tx.id(), &pattern), "transaction id should satisfy test pattern");
+    assert!(Payload::check_header(&tx.payload, prefix));
+
+    let payload = Payload::strip_header(tx.payload.clone());
+    let decoded: EpisodeMessage<TestEpisode> = borsh::from_slice(&payload).expect("decode payload");
+    match decoded {
+        EpisodeMessage::UnsignedCommand { episode_id, cmd } => {
+            assert_eq!(episode_id, 9);
+            assert_eq!(cmd, TestCommand::Add(2));
+        }
+        other => panic!("unexpected payload variant: {other:?}"),
+    }
+
+    assert_eq!(tx.outputs.len(), 1);
+    assert_eq!(tx.outputs[0].value, utxo_amount - fee);
+    let recipient_script = pay_to_address_script(&recipient_address);
+    assert_eq!(tx.outputs[0].script_public_key, recipient_script);
+
+    let expected_first = (TransactionOutpoint::new(tx.id(), 0), UtxoEntry::new(tx.outputs[0].value, tx.outputs[0].script_public_key.clone(), 0, false));
+    let actual_first = get_first_output_utxo(&tx);
+    assert_eq!(actual_first.0, expected_first.0);
+    assert_eq!(actual_first.1.amount, expected_first.1.amount);
+    assert_eq!(actual_first.1.script_public_key, expected_first.1.script_public_key);
+
+    assert_eq!(tx.inputs.len(), 1);
+    assert_eq!(tx.inputs[0].previous_outpoint, utxo.0);
+}


### PR DESCRIPTION
## Summary
- add a dedicated `integration-tests` crate to the workspace with shared fixtures and Kaspa fakes
- cover engine signed/unsigned command handling and reorg rollback in an offline integration test
- verify transaction generator payload encoding and pattern matching without touching the network

## Testing
- not run (per repository guidelines)


------
https://chatgpt.com/codex/tasks/task_e_68cb900851a8832bbd445a7a884b5e40