### PR TITLE
Fix integration-tests crate dependencies

### DIFF
--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "integration-tests"
+version = "0.0.1"
+edition = "2021"
+publish = false
+
+[lib]
+name = "integration_tests"
+path = "src/lib.rs"
+
+[dependencies]
+borsh.workspace = true
+itertools.workspace = true
+kdapp.workspace = true
+kaspa-addresses.workspace = true
+kaspa-consensus-core.workspace = true
+kaspa-txscript.workspace = true
+rand.workspace = true
+secp256k1.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
+workflow-rpc.workspace = true


### PR DESCRIPTION
## Summary
- promote the integration-tests crate's kaspa fixture dependencies from dev-dependencies to normal dependencies so its library sources compile during workspace builds

## Testing
- not run (per repository guidelines)


------
https://chatgpt.com/codex/tasks/task_e_68cba68423f8832ba5b89a54a5b1f1ae